### PR TITLE
Move the console info logic to a module and refactor its styles

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,14 +15,13 @@ jobs:
         node-version: '16'
         cache: 'yarn'
         registry-url: 'https://registry.npmjs.org'
+    - name: Set version number
+      run: |
+        sed -i 's/"version":\s"[^"]*"/"version": "${{ github.ref }}"/' package.json
     - name: Install deps
       run: yarn install --frozen-lockfile 
     - name: Build
       run: yarn build
-    - name: Set version number
-      run: |
-        sed -i 's|*DEV|${{ github.ref }}|g' dist/kiosk-mode.js
-        sed -i 's|refs/tags/||' dist/kiosk-mode.js
     - name: Upload release asset
       uses: svenstaro/upload-release-action@v2
       with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiosk-mode",
-  "version": "1.7.6",
+  "version": "1.7.8",
   "description": "Hides the Home Assistant header and/or sidebar",
   "main": "kiosk-mode.js",
   "repository": "git@github.com:NemesisRE/kiosk-mode.git",
@@ -10,6 +10,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^6.0.0",
     "rollup": "^3.19.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^3.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,10 @@
 import ts from 'rollup-plugin-ts';
+import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
 
 export default {
     plugins: [
+        json(),
         ts({
             browserslist: ["last 2 versions", "not dead", "> 0.2%"]
         }),

--- a/src/conf-info.ts
+++ b/src/conf-info.ts
@@ -1,0 +1,95 @@
+import { getCSSString } from '@utilities';
+import packageJson from '../package.json';
+
+interface Line {
+    content: string;
+    color?: string;
+    background?: string;
+}
+
+const MAX_LENGTH = 27;
+
+export class ConInfo {
+
+    constructor() {
+        this.lines = [
+            {
+                content: '%c≡ kiosk-mode',
+                color: 'white',
+                background: '#03a9f4'
+            },
+            {
+                content: `%cversion ${packageJson.version}`
+            }
+        ];
+    }
+
+    private lines: Line[];
+
+    public log() {
+        const contents: string[] = [];
+        const styles: string[] = [];
+        const lastIndex = this.lines.length - 1;
+        const commonStyles = {
+            'display'      : 'inline-block',
+            'font-size'    : '12px',
+            'border-style' : 'solid',
+            'border-color' : '#424242',
+        };
+
+        this.lines.forEach((line: Line, index: number): void => {
+
+            // contents
+            contents.push(line.content.padEnd(MAX_LENGTH));
+            contents.push('%c⋮');
+
+            if (index !== lastIndex) contents.push('%c\n');
+
+            // styles
+            let borderWidthStart = '0 0 0 1px';
+            let borderWidthEnd = '0 1px 0 1px';
+
+            if (lastIndex === 0) {
+                borderWidthStart = '1px 0 1px 1px';
+                borderWidthEnd = '1px 1px 1px 0';
+            } else if (index === 0) {
+                borderWidthStart = '1px 0 0 1px';
+                borderWidthEnd = '1px 1px 0 0';
+            } else if (index === lastIndex) {
+                borderWidthStart = '0 0 1px 1px';
+                borderWidthEnd = '0 1px 1px 0';
+            }
+
+            styles.push(
+                getCSSString({
+                    ...commonStyles,
+                    'background'   : line.background || 'white',
+                    'color'        : line.color || '#424242',
+                    'padding'      : index === 0
+                        ? '5px 0 5px 5px'
+                        : '7px 0 7px 10px',
+                    'border-width' : borderWidthStart,
+                })
+            );
+
+            styles.push(
+                getCSSString({
+                    ...commonStyles,
+                    'background'   : line.background || 'white',
+                    'color'        : line.color || 'white',
+                    'padding'      : index === 0
+                        ? '5px'
+                        : '7px 5px 7px 0px',
+                    'border-width' : borderWidthEnd,
+                })
+            );
+
+            if (index !== lastIndex) styles.push('');
+
+        });
+
+        console.info(contents.join(''), ...styles);
+
+    }
+
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,11 +87,6 @@ export interface HassConnection {
     }
 }
 
-export type ConInfo = {
-    header: string;
-    ver: string;
-};
-
 export type StyleElement = HTMLElement | ShadowRoot | HTMLElement[] | ShadowRoot[];
 
 declare global {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
         "@utilities": ["utilities"]      
       }
     },
-    "include": ["src/**/*.ts"],
+    "include": ["src/**/*.ts", "package.json"],
     "exclude": ["node_modules"]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,14 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.2.42.tgz#c6672c6008ca36846c46930d39c8aa342cff85d3"
   integrity sha512-CD/2ai1W45cDN/zN2AcYduDavU+nq9aStyQizi4MHxnwkRvS/H24WIjgc1qD8CISoqXa8AAIe+A+zpWxwV7a2Q==
 
-"@rollup/pluginutils@^5.0.2":
+"@rollup/plugin-json@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-6.0.0.tgz#199fea6670fd4dfb1f4932250569b14719db234a"
+  integrity sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+
+"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
   integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==


### PR DESCRIPTION
This pull request does some refactoring related to the `console.info` logic to display the version of the library:

* moves the logic of the `console.info` to a separated module.
* set the version of the package in the `package.json` and later take this version directly to use it in the `console.info`
* removed complexity of the logic
* some styling adjustments

### Styles adjustments

| Before | After |
| ------ | ------ |
|  <img width="312" alt="image" src="https://user-images.githubusercontent.com/3728220/227051463-25322da5-365b-4030-be85-bfa13ca956e2.png"> |  <img width="319" alt="image" src="https://user-images.githubusercontent.com/3728220/227052612-aa5a702c-b220-409a-8f1c-2c3fbf5192ed.png"> |