### PR TITLE
Implement a block mouse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,19 @@ resources:
 
 ## Config Options
 
-| Config Option | Type | Default | Description |
-|:---------------|:---------------|:---------------|:----------|
-|`kiosk:`| Boolean | false | Hides both the header and sidebar.
-|`hide_header:` | Boolean | false | Hides only the header.
-|`hide_sidebar:` | Boolean | false | Hides only the sidebar. Disables swipe to open.
-|`hide_menubutton:` | Boolean | false | Hides only the sidebar menu icon. Does not disable swipe to open.
-|`hide_overflow:` | Boolean | false | Hides the top right menu.
-|`hide_account:` | Boolean | false | Hides the account icon.
-|`hide_search:` | Boolean | false | Hides the search icon.
-|`hide_assistant:` | Boolean | false | Hides the assistant icon.
-|`ignore_entity_settings:` | Boolean | false | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored.
-|`ignore_mobile_settings:` | Boolean | false | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored.
+| Config Option            | Type    | Default | Description |
+|:-------------------------|:--------|:--------|:------------|
+|`kiosk:`                  | Boolean | false   | Hides both the header and sidebar. |
+|`hide_header:`            | Boolean | false   | Hides only the header. |
+|`hide_sidebar:`           | Boolean | false   | Hides only the sidebar. Disables swipe to open. |
+|`hide_menubutton:`        | Boolean | false   | Hides only the sidebar menu icon. Does not disable swipe to open. |
+|`hide_overflow:`          | Boolean | false   | Hides the top right menu. |
+|`hide_account:`           | Boolean | false   | Hides the account icon. |
+|`hide_search:`            | Boolean | false   | Hides the search icon. |
+|`hide_assistant:`         | Boolean | false   | Hides the assistant icon. |
+|`block_mouse:`            | Boolean | false   | Blocks completely the mouse. No interaction is allowed and the mouse will not be visible. **Can only be disabled with `?disable_km` query parameter in the URL.** |
+|`ignore_entity_settings:` | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
+|`ignore_mobile_settings:` | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
 
 ## Simple config example
 
@@ -187,6 +188,8 @@ The query string options are:
 * `?hide_menubutton` to hide sidebar menu button
 * `?hide_account` to hide the account icon
 * `?hide_search` to hide the search icon
+* `?hide_assistant` to hide the assistant icon
+* `?block_mouse` to block completely the mouse
 
 ## Query String Caching
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiosk-mode",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "Hides the Home Assistant header and/or sidebar",
   "main": "kiosk-mode.js",
   "repository": "git@github.com:NemesisRE/kiosk-mode.git",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,7 +7,8 @@ export enum CACHE {
     MENU_BUTTON = 'kmMenuButton',
     ACCOUNT = 'kmAccount',
     SEARCH = 'kmSearch',
-    ASSISTANT = 'kmAssistant'
+    ASSISTANT = 'kmAssistant',
+    MOUSE = 'kmMouse'
 }
 
 export enum OPTION {
@@ -21,7 +22,8 @@ export enum OPTION {
     HIDE_MENU_BUTTON = 'hide_menubutton',
     HIDE_ACCOUNT = 'hide_account',
     HIDE_SEARCH = 'hide_search',
-    HIDE_ASSISTANT = 'hide_assistant'
+    HIDE_ASSISTANT = 'hide_assistant',
+    BLOCK_MOUSE = 'block_mouse'
 }
 
 export enum ELEMENT {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface KioskConfig {
     hide_account?: boolean;
     hide_search?: boolean;
     hide_assistant?: boolean;
+    block_mouse?: boolean;
     admin_settings?: ConditionalKioskConfig;
     non_admin_settings?: ConditionalKioskConfig;
     user_settings?: UserSetting[];


### PR DESCRIPTION
This pull request implements a `block_mouse` option that will hide the mouse and avoid any interaction with the interface. Useful if one wants to allow certain users to see the dashboards but not interact with them. Also, it could be useful in certain environments in which the device is used only to show information and one doesn‘t want the mouse to be visible (check https://github.com/NemesisRE/kiosk-mode/issues/24).

Closes #24 