### PR TITLE
Make kiosk-mode compatible with Home Assistant 2023.4

### DIFF
--- a/src/conf-info.ts
+++ b/src/conf-info.ts
@@ -1,5 +1,5 @@
 import { getCSSString } from '@utilities';
-import packageJson from '../package.json';
+import { version } from '../package.json';
 
 interface Line {
     content: string;
@@ -19,7 +19,7 @@ export class ConInfo {
                 background: '#03a9f4'
             },
             {
-                content: `%cversion ${packageJson.version}`
+                content: `%cversion ${version}`
             }
         ];
     }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -77,7 +77,11 @@ export enum ELEMENT {
     APP_DRAWER_LAYOUT = 'app-drawer-layout',
     APP_TOOLBAR = 'app-toolbar',
     APP_DRAWER = 'app-drawer',
-    HA_SIDEBAR = 'ha-sidebar'
+    HA_SIDEBAR = 'ha-sidebar',
+    // Home Assistant 2023.4
+    HA_DRAWER = 'ha-drawer',
+    TOOLBAR = '.toolbar',
+    ACTION_ITEMS = '.action-items'
 }
 
 export const TRUE = 'true';

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -5,34 +5,60 @@ import {
 } from '@utilities';
 
 const APP_TOOLBAR = 'app-toolbar';
+const TOOLBAR = '.toolbar';
+const ACTION_ITEMS = '.action-items';
 const BUTTON_MENU = 'ha-button-menu';
 const OVERFLOW_BUTTON_MENU = 'mwc-list-item';
 
-export const STYLES = {
+const STYLES_COMMON = {
     HEADER: getCSSRulesString({
         '#view': {
           'min-height': '100vh !important',
           '--header-height': '0'
-        },
-        'app-header': {
-          'display': 'none'
-        }
-    }),
-    SIDEBAR: getCSSRulesString({
-        ':host': {
-          '--app-drawer-width': '0 !important',
-        },
-        '#drawer': {
-          'display': 'none'
         }
     }),
     ACCOUNT: getDisplayNoneRulesString('.profile'),
     MENU_BUTTON: getDisplayNoneRulesString('.menu ha-icon-button'),
     MENU_BUTTON_BURGER: getDisplayNoneRulesString('ha-menu-button'),
-    OVERFLOW_MENU: getDisplayNoneRulesString(`${APP_TOOLBAR} > ${BUTTON_MENU}`),
-    OVERFLOW_MENU_EMPTY: getDisplayNoneRulesString(
+    MOUSE: getCSSRulesString({
+        'body::after': {
+          'bottom': '0',
+          'content': '""',
+          'cursor': 'none',
+          'display': 'block',
+          'left': '0',
+          'position': 'fixed',
+          'right': '0',
+          'top': '0',
+          'z-index': '999999'
+        }
+    })
+};
+
+const STYLES_LEGACY = {
+    HEADER: getCSSRulesString({
+        'app-header': {
+            'display': 'none'
+        }
+    }),
+    SIDEBAR: getCSSRulesString({
+        ':host': {
+            '--app-drawer-width': '0 !important'
+        },
+        '#drawer': {
+            'display': 'none'
+        },
+    }),
+    OVERFLOW_MENU: getDisplayNoneRulesString(
+        `${APP_TOOLBAR} > ${BUTTON_MENU}`
+    ),
+    OVERFLOW_MENU_EMPTY_DESKTOP: getDisplayNoneRulesString(
         `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="1"]`,
         `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="4"]`
+    ),
+    OVERFLOW_MENU_EMPTY_MOBILE: getDisplayNoneRulesString(
+        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="3"]`,
+        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="6"]`
     ),
     SEARCH: getDisplayNoneRulesString(
         `${APP_TOOLBAR} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
@@ -53,18 +79,102 @@ export const STYLES = {
     ),
     EDIT_DASHBOARD: getDisplayNoneRulesString(
         `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.EDIT_DASHBOARD}"]`
-    ),
-    MOUSE: getCSSRulesString({
-        'body::after': {
-          'bottom': '0',
-          'content': '""',
-          'cursor': 'none',
-          'display': 'block',
-          'left': '0',
-          'position': 'fixed',
-          'right': '0',
-          'top': '0',
-          'z-index': '999999'
+    )
+};
+
+const STYLES = {
+    HEADER: getCSSRulesString({
+        '.header': {
+            'display': 'none'
         }
-    })
+    }),
+    SIDEBAR: getCSSRulesString({
+        ':host': {
+          '--mdc-drawer-width': '0 !important'
+        },
+        'partial-panel-resolver': {
+            '--mdc-top-app-bar-width': '100% !important'
+        },
+        'ha-drawer > ha-sidebar': {
+            'display': 'none'
+        },
+        '.header': {
+            'width': '100% !important'
+        }
+        
+    }),
+    OVERFLOW_MENU: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}`
+    ),
+    OVERFLOW_MENU_EMPTY_DESKTOP: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="1"]`,
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="4"]`
+    ),
+    OVERFLOW_MENU_EMPTY_MOBILE: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="3"]`,
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="6"]`
+    ),
+    SEARCH: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.SEARCH}"]`
+    ),
+    ASSISTANT: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.ASSIST}"]`,
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.ASSIST}"]`
+    ),
+    REFRESH: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.REFRESH}"]`
+    ),
+    UNUSED_ENTITIES: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.UNUSED_ENTITIES}"]`,
+    ),
+    RELOAD_RESOURCES: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.RELOAD_RESOURCES}"]`
+    ),
+    EDIT_DASHBOARD: getDisplayNoneRulesString(
+        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.EDIT_DASHBOARD}"]`
+    )
+};
+
+export const getStyles = (isLegacy: boolean) => {
+
+    // If it is legacy Home Assistant
+    if (isLegacy) {
+        return {
+            HEADER: `${STYLES_COMMON.HEADER}${STYLES_LEGACY.HEADER}`,
+            SIDEBAR: STYLES_LEGACY.SIDEBAR,
+            ACCOUNT: STYLES_COMMON.ACCOUNT,
+            MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
+            MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
+            OVERFLOW_MENU: STYLES_LEGACY.OVERFLOW_MENU,
+            OVERFLOW_MENU_EMPTY_DESKTOP: STYLES_LEGACY.OVERFLOW_MENU_EMPTY_DESKTOP,
+            OVERFLOW_MENU_EMPTY_MOBILE: STYLES_LEGACY.OVERFLOW_MENU_EMPTY_MOBILE,
+            SEARCH: STYLES_LEGACY.SEARCH,
+            ASSISTANT: STYLES_LEGACY.ASSISTANT,
+            REFRESH: STYLES_LEGACY.REFRESH,
+            UNUSED_ENTITIES: STYLES_LEGACY.UNUSED_ENTITIES,
+            RELOAD_RESOURCES: STYLES_LEGACY.RELOAD_RESOURCES,
+            EDIT_DASHBOARD: STYLES_LEGACY.EDIT_DASHBOARD,
+            MOUSE: STYLES_COMMON.MOUSE
+        };
+    }
+
+    // Home Assistant >= 2023.4.x
+    return {
+        HEADER: `${STYLES_COMMON.HEADER}${STYLES.HEADER}`,
+        SIDEBAR: STYLES.SIDEBAR,
+        ACCOUNT: STYLES_COMMON.ACCOUNT,
+        MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
+        MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
+        OVERFLOW_MENU: STYLES.OVERFLOW_MENU,
+        OVERFLOW_MENU_EMPTY_DESKTOP: STYLES.OVERFLOW_MENU_EMPTY_DESKTOP,
+        OVERFLOW_MENU_EMPTY_MOBILE: STYLES.OVERFLOW_MENU_EMPTY_MOBILE,
+        SEARCH: STYLES.SEARCH,
+        ASSISTANT: STYLES.ASSISTANT,
+        REFRESH: STYLES.REFRESH,
+        UNUSED_ENTITIES: STYLES.UNUSED_ENTITIES,
+        RELOAD_RESOURCES: STYLES.RELOAD_RESOURCES,
+        EDIT_DASHBOARD: STYLES.EDIT_DASHBOARD,
+        MOUSE: STYLES_COMMON.MOUSE
+    };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ export interface KioskModeRunner {
     run: (lovelace: HTMLElement) => void;
 }
 
+export type Version = [number, number, string];
+
 export interface User {
     name: string;
     is_admin: boolean;
@@ -55,6 +57,9 @@ export interface EntityState {
 export class HomeAssistant extends HTMLElement {
     hass: {
         user: User;
+        config: {
+            version: string;
+        };
         language: string;
         resources: Record<string, Record<string, string>>;
         panelUrl: string;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,4 +1,4 @@
-import { StyleElement } from '@types';
+import { StyleElement, Version } from '@types';
 import { STYLES_PREFIX, TRUE, MENU_REFERENCES } from '@constants';
 
 // Convert to array
@@ -85,4 +85,27 @@ export const getMenuTranslations = (resources: Record<string, string>): Record<s
         return [resources[prop], reference];
     });
     return Object.fromEntries(menuTranslationsEntries);
+};
+
+export const parseVersion = (version: string | undefined): Version | null => {
+    const versionRegExp = /^(\d+)\.(\d+)\.(\w+)$/;
+    const match = version
+        ? version.match(versionRegExp)
+        : null;
+    if (match) {
+        return [
+            +match[1],
+            +match[2],
+            match[3]
+        ];
+    }
+    return null;
+};
+
+export const isLegacyVersion = (version: string | undefined): boolean => {
+    const parsedVersion = parseVersion(version);
+    if (version) {
+        return parsedVersion[0] <= 2023 && parsedVersion[1] <= 3;
+    }
+    return false;
 };


### PR DESCRIPTION
This pull request makes the necessary changes to make `kiosk-mode` compatible with Home Assistant 2023.4 (released on April 5th). The changes have been made in a way that the library is still compatible with previous versions of Home Assistant.

>Note: this pull request depends on https://github.com/NemesisRE/kiosk-mode/pull/26, it contains the same changes contained in the aforementioned pull request. After https://github.com/NemesisRE/kiosk-mode/pull/26 gets merged, this branch should be rebased to keep only the changes relatives to the new features introduced here.