### PR TITLE
Set the height of the header in pixels

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -14,7 +14,7 @@ const STYLES_COMMON = {
     HEADER: getCSSRulesString({
         '#view': {
           'min-height': '100vh !important',
-          '--header-height': '0'
+          '--header-height': '0px'
         }
     }),
     ACCOUNT: getDisplayNoneRulesString('.profile'),


### PR DESCRIPTION
Kiosk mode sets the height of the header in `0` changing the `--header-height` variable. This variable is used to set the height of the `#view` element in this way:

```
height: calc(100vh - var(--header-height) - env(safe-area-inset-top))
```

And `100vh - 0` fails because `0` doesn‘t have units. This is problematic with those themes that set  a background in this specific element. 

This pull request changes the value of the variable `--header-height` in `0px` something that will fix this issue.

Closes #43