### PR TITLE
Hide aside element when hide_sidebar is true

### DIFF
--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -325,9 +325,15 @@ class KioskMode implements KioskModeRunner {
 
     if (this.hideSidebar) {
       addStyle(STYLES.SIDEBAR, this.drawerLayout);
+      if (!this.isLegacy) {
+        addStyle(STYLES.ASIDE, this.drawerLayout.shadowRoot);
+      }
       if (queryString(OPTION.CACHE)) setCache(CACHE.SIDEBAR, TRUE);
     } else {
       removeStyle(this.drawerLayout);
+      if (!this.isLegacy) {
+        removeStyle(this.drawerLayout.shadowRoot);
+      }
     }
 
     if (
@@ -389,7 +395,7 @@ class KioskMode implements KioskModeRunner {
           )
             ? STYLES.OVERFLOW_MENU_EMPTY_MOBILE
             : '',
-          this.hideMenuButton ||  this.hideSidebar ? STYLES.MENU_BUTTON_BURGER : '',
+          this.hideMenuButton || this.hideSidebar ? STYLES.MENU_BUTTON_BURGER : '',
           
       ];
       addStyle(styles.join(''), this.appToolbar);

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -103,6 +103,7 @@ const STYLES = {
         }
         
     }),
+    ASIDE: getDisplayNoneRulesString('.mdc-drawer'),
     OVERFLOW_MENU: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}`
     ),
@@ -143,6 +144,7 @@ export const getStyles = (isLegacy: boolean) => {
         return {
             HEADER: `${STYLES_COMMON.HEADER}${STYLES_LEGACY.HEADER}`,
             SIDEBAR: STYLES_LEGACY.SIDEBAR,
+            ASIDE: '',
             ACCOUNT: STYLES_COMMON.ACCOUNT,
             MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
             MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
@@ -163,6 +165,7 @@ export const getStyles = (isLegacy: boolean) => {
     return {
         HEADER: `${STYLES_COMMON.HEADER}${STYLES.HEADER}`,
         SIDEBAR: STYLES.SIDEBAR,
+        ASIDE: STYLES.ASIDE,
         ACCOUNT: STYLES_COMMON.ACCOUNT,
         MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
         MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,


### PR DESCRIPTION
In Home Assistant `2023.4` a new element has been added separating the sidebar from the lovelace dashboard. It is a one pixel line that ends in the left of the dashboard when the sidebar is hidden. This line is not noticeable with some themes, but with others it is perfectly visible and annoying. This pull request hides this element when the sidebar is hidden only in Home Assistant `2023.4` +.

| With sidebar | Without sidebar |
| ------------- | ---------------- |
| ![image](https://user-images.githubusercontent.com/3728220/230960125-5a69099e-b9c2-4520-9760-12d363ded8fc.png) | ![image](https://user-images.githubusercontent.com/3728220/230960208-f4b46d3a-738e-48a4-9329-ca8f955be2af.png) |

Closes #54 