### PR TITLE
Solve some errors selecting elements in Home Assistant

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
+export const NAMESPACE = 'kiosk-mode';
 export const STYLES_PREFIX = 'kiosk_mode';
 
 export enum CACHE {
@@ -89,4 +90,6 @@ export const FALSE = 'false';
 export const CUSTOM_MOBILE_WIDTH_DEFAULT = 812;
 export const SUSCRIBE_EVENTS_TYPE = 'subscribe_events';
 export const STATE_CHANGED_EVENT = 'state_changed';
+export const MAX_ATTEMPTS = 200;
+export const RETRY_DELAY = 50;
 export const WINDOW_RESIZE_DELAY = 250;

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -478,7 +478,7 @@ class KioskMode implements KioskModeRunner {
         });
       })
       .catch(() => {
-        console.error(`${NAMESPACE} Cannot select app toolbar menu items`);
+        console.info(`${NAMESPACE} Cannot select app toolbar menu items`);
       });
 
     getMenuItems(getOverflowMenuItems)
@@ -506,7 +506,7 @@ class KioskMode implements KioskModeRunner {
         } 
       })
       .catch(() => {
-        console.error(`${NAMESPACE} Cannot select overflow menu items`);
+        console.info(`${NAMESPACE} Cannot select overflow menu items`);
       });
     
   }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,5 +1,10 @@
 import { StyleElement, Version } from '@types';
-import { STYLES_PREFIX, TRUE, MENU_REFERENCES } from '@constants';
+import {
+    STYLES_PREFIX,
+    TRUE,
+    MENU_REFERENCES,
+    MAX_ATTEMPTS
+} from '@constants';
 
 // Convert to array
 export const toArray = <T>(x: T | T[]): T[] => {
@@ -108,4 +113,24 @@ export const isLegacyVersion = (version: string | undefined): boolean => {
         return parsedVersion[0] <= 2023 && parsedVersion[1] <= 3;
     }
     return false;
+};
+
+export const getMenuItems = (getElements: () => NodeListOf<HTMLElement>): Promise<NodeListOf<HTMLElement>> => {
+    return new Promise((resolve, reject) => {
+        let attempts = 0;
+        const select = () => {
+            const items = getElements();
+            if (items && items.length) {
+                resolve(items);
+            } else {
+                attempts++;
+                if (attempts < MAX_ATTEMPTS) {
+                    select();
+                } else {
+                    reject();
+                }
+            }
+        };
+        select();
+    });
 };

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,9 +1,14 @@
-import { StyleElement, Version } from '@types';
+import {
+    HomeAssistant,
+    StyleElement,
+    Version
+} from '@types';
 import {
     STYLES_PREFIX,
     TRUE,
     MENU_REFERENCES,
-    MAX_ATTEMPTS
+    MAX_ATTEMPTS,
+    RETRY_DELAY
 } from '@constants';
 
 // Convert to array
@@ -83,11 +88,51 @@ export const getDisplayNoneRulesString = (...rules: string[]): string => {
     }).join('');
 };
 
-export const getMenuTranslations = (resources: Record<string, string>): Record<string, string> => {
+const getHAResources = (ha: HomeAssistant): Promise<Record<string, Record<string, string>>> => {
+    let attempts = 0;
+    const referencePaths = Object.values(MENU_REFERENCES);
+    return new Promise((resolve, reject) => {
+        const getResources = () => {
+            const resources = ha?.hass?.resources;
+            let success = false;
+            if (resources) {
+                const language = ha.hass.language;
+                // check if all the resources are available
+                const anyEmptyResource = referencePaths.find((path: string) => {
+                    if (resources[language][path]) {
+                        return false;
+                    }
+                    return true;
+                });
+                if (!anyEmptyResource) {
+                    success = true;
+                }
+            }
+            if (success) {
+                resolve(resources);
+            } else {
+                attempts++;
+                if (attempts < MAX_ATTEMPTS) {
+                    setTimeout(getResources, RETRY_DELAY);
+                } else {
+                    reject();
+                }
+            }
+        };
+        getResources();
+    });
+}
+
+export const getMenuTranslations = async(
+    ha: HomeAssistant
+): Promise<Record<string, string>> => {
+    const resources = await getHAResources(ha);
+    const language = ha.hass.language;
+    const resourcesTranslated = resources[language];
     const entries = Object.entries(MENU_REFERENCES);
     const menuTranslationsEntries = entries.map((entry: [string, string]) => {
         const [reference, prop] = entry;
-        return [resources[prop], reference];
+        return [resourcesTranslated[prop], reference];
     });
     return Object.fromEntries(menuTranslationsEntries);
 };


### PR DESCRIPTION
When one changes tabs quickly, sometimes this error appears.

>Uncaught TypeError: Cannot read properties of null (reading 'dataset')

`kiosk-mode` tries to select these elements when they are not fully rendered in the UI.

Also, in Firefox browser, the resources inside `hass` are created later than in other brosers, so trying to access them when `kiosk-mode` is executed ends up with this error:

>Uncaught (in promise) TypeError: this.ha.hass.resources is null

This pull request selects the menu items and the `hass` resources using promises, so these elements are used only when they are available, solving these errors completely.

Closes #63 

