### PR TITLE
Ignore disable_km option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,17 @@ views:
 |`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right menu in lovelace yaml mode |
 |`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right menu in lovelace yaml mode |
 |`block_mouse:`            | Boolean | false   | Blocks completely the mouse. No interaction is allowed and the mouse will not be visible. **Can only be disabled with `?disable_km` query parameter in the URL.** |
-|`ignore_entity_settings:` | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
-|`ignore_mobile_settings:` | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
+|`ignore_entity_settings:`\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
+|`ignore_mobile_settings:`\*\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
+|`ignore_disable_km:`\*      | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `disable_km` URL parameter to be ignored. |
+
+<br/>
+
+>\* These options only work if they are placed inside [admin_settings](#admin_settings), [non_admin_settings](#non_admin_settings), [user_settings](#user_settings) or [mobile_settings](#mobile_settings). They will not have any effect if they are placed inside [entity_settings](#entity_settings)
+>
+>\*\* This option only works if it is placed inside [admin_settings](#admin_settings), [non_admin_settings](#non_admin_settings) or [user_settings](#user_settings). It will not have any effect if it is placed inside [mobile_settings](#mobile_settings) or [entity_settings](#entity_settings)
+
+<br/>
 
 ## Conditional Lovelace Config
 Contitional configs take priority and if a condition matches all other config options/methods are ignored.
@@ -211,7 +220,7 @@ This works for all query strings except for the utility strings listed below.
 **Utility Query Strings**
 
 * `?clear_km_cache` will clear all cached preferences
-* `?disable_km` will temporarily disable any modifications
+* `?disable_km` will temporarily disable any modifications (unless `ignore_disable_km` has been used in one of the [conditional configs](#conditional-lovelace-config))
 <br>
 
 ## Kiosk-mode demo

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -86,6 +86,7 @@ export enum ELEMENT {
 
 export const TRUE = 'true';
 export const FALSE = 'false';
+export const BOOLEAN = 'boolean';
 export const CUSTOM_MOBILE_WIDTH_DEFAULT = 812;
 export const SUSCRIBE_EVENTS_TYPE = 'subscribe_events';
 export const STATE_CHANGED_EVENT = 'state_changed';

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -13,6 +13,7 @@ import {
   ELEMENT,
   TRUE,
   FALSE,
+  BOOLEAN,
   CUSTOM_MOBILE_WIDTH_DEFAULT,
   SUSCRIBE_EVENTS_TYPE,
   STATE_CHANGED_EVENT,
@@ -101,9 +102,10 @@ class KioskMode implements KioskModeRunner {
   private blockMouse: boolean;
   private ignoreEntity: boolean;
   private ignoreMobile: boolean;
+  private ignoreDisableKm: boolean;
 
   public run(lovelace = this.main.querySelector<Lovelace>(ELEMENT.HA_PANEL_LOVELACE)) {
-    if (queryString(OPTION.DISABLE_KIOSK_MODE) || !lovelace) {
+    if (!lovelace) {
       return;
     }
     this.lovelace = lovelace;
@@ -146,6 +148,7 @@ class KioskMode implements KioskModeRunner {
     this.blockMouse          = false;
     this.ignoreEntity        = false;
     this.ignoreMobile        = false;
+    this.ignoreDisableKm     = false;
 
     this.mode = this.lovelace.lovelace.mode;
     this.huiRoot = this.lovelace.shadowRoot.querySelector(ELEMENT.HUI_ROOT).shadowRoot;
@@ -307,6 +310,14 @@ class KioskMode implements KioskModeRunner {
           if (OPTION.KIOSK in conf)                 this.hideHeader          = this.hideSidebar = conf[OPTION.KIOSK];
         }
       }
+    }
+
+    // Do not run kiosk-mode if it is disabled
+    if (
+      queryString(OPTION.DISABLE_KIOSK_MODE) &&
+      !this.ignoreDisableKm
+    ) {
+      return;
     }
 
     this.insertStyles();
@@ -511,8 +522,15 @@ class KioskMode implements KioskModeRunner {
     this.hideReloadResources = config.kiosk || config.hide_reload_resources;
     this.hideEditDashboard   = config.kiosk || config.hide_edit_dashboard;
     this.blockMouse          = config.block_mouse;
-    this.ignoreEntity        = config.ignore_entity_settings;
-    this.ignoreMobile        = config.ignore_mobile_settings;
+    this.ignoreEntity        = typeof config.ignore_entity_settings === BOOLEAN
+      ? config.ignore_entity_settings
+      : this.ignoreEntity;
+    this.ignoreMobile        = typeof config.ignore_mobile_settings === BOOLEAN
+      ? config.ignore_mobile_settings
+      : this.ignoreMobile;
+    this.ignoreDisableKm     = typeof config.ignore_disable_km === BOOLEAN
+      ? config.ignore_disable_km
+      : this.ignoreDisableKm;
   }
 
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,7 @@ export interface KioskConfig {
 export interface ConditionalKioskConfig extends KioskConfig {
     ignore_entity_settings?: boolean;
     ignore_mobile_settings?: boolean;
+    ignore_disable_km?: boolean;
 }
 
 export interface EntityState {


### PR DESCRIPTION
This pull request adds a new option for the [conditional configs](https://github.com/NemesisRE/kiosk-mode#conditional-lovelace-config).

### ignore_disable_km

If this option is set in one of the conditional configs (excluding `entity_settings`) it will ignore the `disable_km` parameter.

#### Do not allow admins to disable kiosk mode through the URL parameter:

```yaml
kiosk_mode:
    admin_settings:
        ignore_disable_km: true
```

#### Do not allow non-admins to disable kiosk mode through the URL parameter:

```yaml
kiosk_mode:
    non_admin_settings:
        ignore_disable_km: true
```

#### Do not allow certain users to disable kiosk mode through the URL parameter:

```yaml
kiosk_mode:
  user_settings:
    - users:
        - "ryan meek"
        - "maykar"
      ignore_disable_km: true
```

#### Do not allow to disable kiosk mode through the URL parameter in a mobile device:

```yaml
kiosk_mode:
    mobile_settings:
        ignore_disable_km: true
```

>Note: as part of this pull request the documentation has been modifyed to make it clear in which conditional configurations the options `ignore_entity_settings`, `ignore_mobile_settings` and `ignore_disable_km` will work.

Closes #47 