### PR TITLE
Add a delay to the getMenuItems utility method

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -170,7 +170,7 @@ export const getMenuItems = (getElements: () => NodeListOf<HTMLElement>): Promis
             } else {
                 attempts++;
                 if (attempts < MAX_ATTEMPTS) {
-                    select();
+                    setTimeout(select, RETRY_DELAY);
                 } else {
                     reject();
                 }


### PR DESCRIPTION
This pull request adds a delay to the `getMenuItems` utiity method to retry a retrieval after 50 milliseconds.