### PR TITLE
Update Home Assistant Docker image and remove config files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 /dist
 .DS_Store
 .hass/config/www/kiosk-mode.js
-.hass/config/.storage
-.hass/config/blueprints
-.hass/config/home-assistant*

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "version": "git add .",
     "postversion": "git push && git push --tags",
     "copy-kiosk-mode": "copyfiles -f dist/kiosk-mode.js .hass/config/www",
-    "start:ha": "docker run --rm -p8123:8123 -v ${PWD}/.hass/config:/config homeassistant/home-assistant:2023.4",
-    "start:ha:win": "docker run --rm -p8123:8123 -v %cd%/.hass/config:/config homeassistant/home-assistant:2023.4",
+    "start:ha": "docker run --rm -p8123:8123 -v ${PWD}/.hass/config:/config homeassistant/home-assistant:2023.4.6",
+    "start:ha:win": "docker run --rm -p8123:8123 -v %cd%/.hass/config:/config homeassistant/home-assistant:2023.4.6",
     "demo": "yarn build && yarn copy-kiosk-mode && yarn start:ha",
     "demo:win": "yarn build && yarn copy-kiosk-mode && yarn start:ha:win"
   },


### PR DESCRIPTION
This pull request updates the docker image for the demo to the latest tag and removes HA config files from `.gitignore`.