### PR TITLE
Change documentation to reflect the current behaviour with the sidebar open gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ views:
 | Config Option            | Type    | Default | Description |
 |:-------------------------|:--------|:--------|:------------|
 |`kiosk:`                  | Boolean | false   | Hides both the header and sidebar. |
-|`hide_header:`            | Boolean | false   | Hides only the header. |
-|`hide_sidebar:`           | Boolean | false   | Hides only the sidebar. Disables swipe to open. |
-|`hide_menubutton:`        | Boolean | false   | Hides only the sidebar menu icon. Does not disable swipe to open. |
+|`hide_header:`\*          | Boolean | false   | Hides only the header. |
+|`hide_sidebar:`           | Boolean | false   | Hides only the sidebar. |
+|`hide_menubutton:`\*      | Boolean | false   | Hides only the sidebar menu icon. |
 |`hide_overflow:`          | Boolean | false   | Hides the top right menu. |
 |`hide_account:`           | Boolean | false   | Hides the account icon. |
 |`hide_search:`            | Boolean | false   | Hides the search icon. |
@@ -85,15 +85,17 @@ views:
 |`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right menu in lovelace yaml mode |
 |`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right menu in lovelace yaml mode |
 |`block_mouse:`            | Boolean | false   | Blocks completely the mouse. No interaction is allowed and the mouse will not be visible. **Can only be disabled with `?disable_km` query parameter in the URL.** |
-|`ignore_entity_settings:`\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
-|`ignore_mobile_settings:`\*\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
-|`ignore_disable_km:`\*      | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `disable_km` URL parameter to be ignored. |
+|`ignore_entity_settings:`\** | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
+|`ignore_mobile_settings:`\*\*\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
+|`ignore_disable_km:`\**      | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `disable_km` URL parameter to be ignored. |
 
 <br/>
 
->\* These options only work if they are placed inside [admin_settings](#admin_settings), [non_admin_settings](#non_admin_settings), [user_settings](#user_settings) or [mobile_settings](#mobile_settings). They will not have any effect if they are placed inside [entity_settings](#entity_settings)
+>\* Take into account that swipe gesture to open the sidebar was removed from Home Assistant in version 2023.4, if you hide the header or the sidebar menu icon, you will not have any way to access the sidebar natively in a browser.
 >
->\*\* This option only works if it is placed inside [admin_settings](#admin_settings), [non_admin_settings](#non_admin_settings) or [user_settings](#user_settings). It will not have any effect if it is placed inside [mobile_settings](#mobile_settings) or [entity_settings](#entity_settings)
+>\*\* These options only work if they are placed inside [admin_settings](#admin_settings), [non_admin_settings](#non_admin_settings), [user_settings](#user_settings) or [mobile_settings](#mobile_settings). They will not have any effect if they are placed inside [entity_settings](#entity_settings)
+>
+>\*\*\* This option only works if it is placed inside [admin_settings](#admin_settings), [non_admin_settings](#non_admin_settings) or [user_settings](#user_settings). It will not have any effect if it is placed inside [mobile_settings](#mobile_settings) or [entity_settings](#entity_settings)
 
 <br/>
 


### PR DESCRIPTION
Swiping to open the sidebar was removed from Home Assistant in version 2023.4. The documentation still mentions that enabling or disabling certain elements could change the behaviour related to the sidebar swiping feature, but this is not true anymore. Also, some users think that swipe to open the sidebar is a `kiosk-mode` feature ([here](https://github.com/NemesisRE/kiosk-mode/issues/42), [here](https://github.com/NemesisRE/kiosk-mode/issues/46), [here](https://github.com/NemesisRE/kiosk-mode/issues/49), and [here](https://github.com/NemesisRE/kiosk-mode/issues/71)). This pull request changes the documentation to reflect what is the current behaviour of the sidebar gesture in Home Assistant.