### PR TITLE
Change repository HACS badge by the default one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kiosk-mode
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
 Hides the header and/or sidebar drawer in [Home Assistant](https://www.home-assistant.io/) lovelace dashboards
 


### PR DESCRIPTION
This repository is not a HACS custom anymore, it is the default `kiosk-mode` [available in HACS](https://github.com/hacs/default/blob/965bd935669b92d2eef59ad337f652c689e7477d/plugin#L207), so it should be reflected in this way by its [HACS badge](https://hacs.xyz/docs/publish/start#badges).