### PR TITLE
Make Kiosk Mode detects the Home Assistant version with development tags

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -138,7 +138,7 @@ export const getMenuTranslations = async(
 };
 
 export const parseVersion = (version: string | undefined): Version | null => {
-    const versionRegExp = /^(\d+)\.(\d+)\.(\w+)$/;
+    const versionRegExp = /^(\d+)\.(\d+)\.(\w+)(?:\.(\w+))?$/;
     const match = version
         ? version.match(versionRegExp)
         : null;
@@ -154,7 +154,7 @@ export const parseVersion = (version: string | undefined): Version | null => {
 
 export const isLegacyVersion = (version: string | undefined): boolean => {
     const parsedVersion = parseVersion(version);
-    if (version) {
+    if (parsedVersion) {
         return parsedVersion[0] <= 2023 && parsedVersion[1] <= 3;
     }
     return false;


### PR DESCRIPTION
Development tags have a format similar to the next one `2023.6.0.dev20230531` instead of `2023.6.0`, this makes the version detection logic to fail. This pull request changes the regular expression to detect the Home Assistant version so it can work slso with development tags.

Using `2023.6.0.dev20230531`, `kiosk-mode` will parse it as `[2023, 6, 0]`.

Closes #76