### PR TITLE
Get Lovelace config using a promise

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -91,6 +91,6 @@ export const BOOLEAN = 'boolean';
 export const CUSTOM_MOBILE_WIDTH_DEFAULT = 812;
 export const SUSCRIBE_EVENTS_TYPE = 'subscribe_events';
 export const STATE_CHANGED_EVENT = 'state_changed';
-export const MAX_ATTEMPTS = 200;
+export const MAX_ATTEMPTS = 500;
 export const RETRY_DELAY = 50;
 export const WINDOW_RESIZE_DELAY = 250;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,8 @@
 import {
     HomeAssistant,
     StyleElement,
-    Version
+    Version,
+    Lovelace
 } from '@types';
 import {
     STYLES_PREFIX,
@@ -177,5 +178,25 @@ export const getMenuItems = (getElements: () => NodeListOf<HTMLElement>): Promis
             }
         };
         select();
+    });
+};
+
+export const getLovelaceConfig = (lovelace: Lovelace): Promise<Lovelace['lovelace']['config']> => {
+    return new Promise((resolve, reject) => {
+        let attempts = 0;
+        const getConfig = () => {
+            const config = lovelace?.lovelace?.config;
+            if (config) {
+                resolve(config);
+            } else {
+                attempts++;
+                if (attempts < MAX_ATTEMPTS) {
+                    setTimeout(getConfig, RETRY_DELAY);
+                } else {
+                    reject();
+                }
+            }
+        };
+        getConfig();
     });
 };


### PR DESCRIPTION
At the moment, to get the lovelace configuration, the approach is to execute the whole `kiosk-mode` logic and if it fails, retry again after some seconds. This is unnecessary, if the configuration cannot be retrieved, the default `kiosk-mode` shoudl not be executed.

This pull request tries to get the configuration using a Promise, the maximum number of attempts has been increased from `200` to `500` and as the delay between attempts is `50` milliseconds, the configuration will be try to be retrieved for 25 seconds (which is long enough). If the configuration could not be retrieved after that time, an error is thrown and `kiosk-mode` gives up.

Closes #75 