### PR TITLE
Change console.info styles

### DIFF
--- a/src/conf-info.ts
+++ b/src/conf-info.ts
@@ -31,10 +31,12 @@ export class ConInfo {
         const styles: string[] = [];
         const lastIndex = this.lines.length - 1;
         const commonStyles = {
-            'display'      : 'inline-block',
-            'font-size'    : '12px',
-            'border-style' : 'solid',
             'border-color' : '#424242',
+            'border-style' : 'solid',
+            'display'      : 'inline-block',
+            'font-family'  : 'monospace',
+            'font-size'    : '12px'
+            
         };
 
         this.lines.forEach((line: Line, index: number): void => {
@@ -66,8 +68,8 @@ export class ConInfo {
                     'background'   : line.background || 'white',
                     'color'        : line.color || '#424242',
                     'padding'      : index === 0
-                        ? '5px 0 5px 5px'
-                        : '7px 0 7px 10px',
+                        ? '1px 0px 1px 5px'
+                        : '1px 0px 1px 10px',
                     'border-width' : borderWidthStart,
                 })
             );
@@ -78,8 +80,8 @@ export class ConInfo {
                     'background'   : line.background || 'white',
                     'color'        : line.color || 'white',
                     'padding'      : index === 0
-                        ? '5px'
-                        : '7px 5px 7px 0px',
+                        ? '1px 5px'
+                        : '1px 5px 1px 0px',
                     'border-width' : borderWidthEnd,
                 })
             );


### PR DESCRIPTION
The big paddings used in the `console.info` styles break in Safari.

This pull request removes these big paddings and fixes the `font-family` to make it look similar in Chrome, Firefox and Safari.

### Before and after in Safari

| Before | After |
| ------ | ----- |
| <img width="236" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/3826495a-2383-4d24-9c60-5e7346d19191"> | <img width="333" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/d2e9ad19-cccb-4664-a85d-5d573affb1d5"> |

### How it looks compared to other browsers after the change

| Safari | Chrome | Firefox |
| ------ | -------- | ------ |
| <img width="333" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/d2e9ad19-cccb-4664-a85d-5d573affb1d5"> | <img width="366" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/4d928a40-14ed-4738-9a88-4f6c6d871d91"> | <img width="317" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/7df68eec-9e5b-493f-9d21-20a18be4c0f3"> |