### PR TITLE
Add auto_hide_overflow option

### DIFF
--- a/.hass/config/inputs/booleans/kiosk-mode.yaml
+++ b/.hass/config/inputs/booleans/kiosk-mode.yaml
@@ -22,5 +22,7 @@ kiosk_hide_reload_resources:
   name: Kiosk hide reload resources
 kiosk_hide_edit_dashboard:
   name: Kiosk hide edit dashboard
+kiosk_auto_hide_overflow:
+  name: Kiosk auto hide overflow
 kiosk_block_mouse:
   name: Kiosk block mouse

--- a/.hass/config/ui-lovelace.yaml
+++ b/.hass/config/ui-lovelace.yaml
@@ -34,6 +34,9 @@ kiosk_mode:
         input_boolean.kiosk_hide_edit_dashboard: 'on'
       hide_edit_dashboard: true
     - entity:
+        input_boolean.kiosk_auto_hide_overflow: 'on'
+      auto_hide_overflow: true
+    - entity:
         input_boolean.kiosk_hide_overflow: 'on'
       hide_overflow: true
     - entity:
@@ -61,4 +64,5 @@ views:
           - entity: input_boolean.kiosk_hide_unused_entities
           - entity: input_boolean.kiosk_hide_reload_resources
           - entity: input_boolean.kiosk_hide_edit_dashboard
+          - entity: input_boolean.kiosk_auto_hide_overflow
           - entity: input_boolean.kiosk_block_mouse

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ views:
 |`hide_refresh`            | Boolean | false   | Hides the "Refresh" button inside the top right menu in lovelace yaml mode |
 |`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right menu in lovelace yaml mode |
 |`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right menu in lovelace yaml mode |
+|`auto_hide_overflow`      | Boolean | false   | Hides automatically the top right menu if all its items have been hidden |
 |`block_mouse:`            | Boolean | false   | Blocks completely the mouse. No interaction is allowed and the mouse will not be visible. **Can only be disabled with `?disable_km` query parameter in the URL.** |
 |`ignore_entity_settings:`\** | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
 |`ignore_mobile_settings:`\*\*\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
@@ -209,7 +210,8 @@ The query string options are:
 * `?hide_edit_dashboard` to hide the "Edit dashboard" button inside the top right menu
 * `?hide_refresh` to hide the "Refresh" button inside the top right menu in lovelace yaml mode
 * `?hide_unused_entities` to hide the "Unused entities" button inside the top right menu in lovelace yaml mode
-* `?hide_reload_resources` to the "Reload resources" button inside the top right menu in lovelace yaml mode
+* `?hide_reload_resources` to hide the "Reload resources" button inside the top right menu in lovelace yaml mode
+* `?auto_hide_overflow` to hide automatically the top right menu if all its items have been hidden
 * `?block_mouse` to block completely the mouse
 
 ## Query String Caching

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,6 +13,7 @@ export enum CACHE {
     UNUSED_ENTITIES = 'kmUnusedEntities',
     RELOAD_RESOURCES = 'kmReloadResources',
     EDIT_DASHBOARD = 'kmEditDashboard',
+    AUTO_HIDE_OVERFLOW = 'kmAutoHideOverflow',
     MOUSE = 'kmMouse'
 }
 
@@ -32,6 +33,7 @@ export enum OPTION {
     HIDE_UNUSED_ENTITIES = 'hide_unused_entities',
     HIDE_RELOAD_RESOURCES = 'hide_reload_resources',
     HIDE_EDIT_DASHBOARD = 'hide_edit_dashboard',
+    AUTO_HIDE_OVERFLOW = 'auto_hide_overflow',
     BLOCK_MOUSE = 'block_mouse'
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export interface KioskConfig {
     hide_unused_entities?: boolean;
     hide_reload_resources?: boolean;
     hide_edit_dashboard?: boolean;
+    auto_hide_overflow?: boolean;
     block_mouse?: boolean;
     admin_settings?: ConditionalKioskConfig;
     non_admin_settings?: ConditionalKioskConfig;


### PR DESCRIPTION
This pull request adds a new option to the configuration (`auto_hide_overflow`).

If this option is `false` (default value), the overflow menu will not hide automatically when all its items are hidden. If this option is `true` then the overflow menu will hide if all its items are hidden.

>As part of this pull request the menu translations are retrieved only when the configuration has been retrieved, it doesn‘t make sense to run the menu translations logic if the configuration cannot be retrieved and `kiosk-mode` will not be executed.

Closes #79 