### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "devDependencies": {
     "@rollup/plugin-json": "^6.0.0",
     "copyfiles": "^2.4.1",
-    "rollup": "^3.19.1",
+    "rollup": "^3.23.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^3.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export default {
     plugins: [
         json(),
         ts({
-            browserslist: ["last 2 versions", "not dead", "> 0.2%"]
+            browserslist: false
         }),
         terser({
             output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,10 @@ rollup-plugin-ts@^3.2.0:
     ts-clone-node "^2.0.4"
     tslib "^2.4.1"
 
-rollup@^3.19.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.19.1.tgz#2b3a31ac1ff9f3afab2e523fa687fef5b0ee20fc"
-  integrity sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==
+rollup@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.23.0.tgz#b8d6146dac4bf058ee817f92820988e9b358b564"
+  integrity sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -653,10 +653,10 @@ tslib@^2.4.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 ua-parser-js@^1.0.33:
   version "1.0.34"


### PR DESCRIPTION
This pull request updates `rollup` and `typescript`. Browserlist has been disabled from the rollup config because it tries to set up the target to `ES3`, something that is deprecated in `TypeScript` >= 5, in this case, the target `ES5` defined in the `tsconfig.json` will be used.