### PR TITLE
Clean home assistant < 2023.4.x compatibility

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -77,11 +77,7 @@ export enum ELEMENT {
     MENU_ITEM_ICON = 'mwc-icon-button',
     OVERLAY_MENU = 'ha-button-menu',
     OVERLAY_MENU_ITEM = 'mwc-list-item',
-    APP_DRAWER_LAYOUT = 'app-drawer-layout',
-    APP_TOOLBAR = 'app-toolbar',
-    APP_DRAWER = 'app-drawer',
     HA_SIDEBAR = 'ha-sidebar',
-    // Home Assistant 2023.4
     HA_DRAWER = 'ha-drawer',
     TOOLBAR = '.toolbar',
     ACTION_ITEMS = '.action-items'

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -23,7 +23,6 @@ import {
   NAMESPACE
 } from '@constants';
 import {
-  isLegacyVersion,
   toArray,
   queryString,
   setCache,
@@ -34,7 +33,7 @@ import {
   getMenuTranslations,
   getMenuItems
 } from '@utilities';
-import { getStyles } from '@styles';
+import { STYLES } from '@styles';
 
 import { ConInfo } from './conf-info';
 
@@ -61,7 +60,6 @@ class KioskMode implements KioskModeRunner {
     this.ha = document.querySelector<HomeAssistant>(ELEMENT.HOME_ASSISTANT);
     this.main = this.ha.shadowRoot.querySelector(ELEMENT.HOME_ASSISTANT_MAIN).shadowRoot;
     this.user = this.ha.hass.user;
-    this.isLegacy = isLegacyVersion(this.ha.hass?.config?.version);
     this.resizeWindowBinded = this.resizeWindow.bind(this);
     this.run();
     this.entityWatch();
@@ -74,7 +72,6 @@ class KioskMode implements KioskModeRunner {
   // Elements
   private ha: HomeAssistant;
   private main: ShadowRoot;
-  private isLegacy: boolean;
   private user: User;
   private huiRoot: ShadowRoot;
   private lovelace: Lovelace;
@@ -157,20 +154,10 @@ class KioskMode implements KioskModeRunner {
     this.mode = this.lovelace?.lovelace?.mode || LOVELACE_MODE.STORAGE;
     this.huiRoot = this.lovelace.shadowRoot.querySelector(ELEMENT.HUI_ROOT).shadowRoot;
 
-    if (this.isLegacy) {
-      // Legacy Home Assistant
-      this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.APP_DRAWER_LAYOUT);
-      this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.APP_TOOLBAR);
-      const appDrawer = this.drawerLayout.querySelector(ELEMENT.APP_DRAWER);
-      this.sideBarRoot = appDrawer.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
-      this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.OVERLAY_MENU}`);
-    } else {
-      // Home Assistant >= 2023.4.x
-      this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.HA_DRAWER);
-      this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.TOOLBAR);
-      this.sideBarRoot = this.drawerLayout.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
-      this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.OVERLAY_MENU}`);
-    }
+    this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.HA_DRAWER);
+    this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.TOOLBAR);
+    this.sideBarRoot = this.drawerLayout.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
+    this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.OVERLAY_MENU}`);
 
     // Retrieve localStorage values & query string options.
     const queryStringsSet = (
@@ -334,9 +321,7 @@ class KioskMode implements KioskModeRunner {
     this.insertStyles();
   }
 
-  protected insertStyles() {  
-    
-    const STYLES = getStyles(this.isLegacy);
+  protected insertStyles() {
   
     if (this.hideHeader) {
       addStyle(STYLES.HEADER, this.huiRoot);
@@ -347,15 +332,11 @@ class KioskMode implements KioskModeRunner {
 
     if (this.hideSidebar) {
       addStyle(STYLES.SIDEBAR, this.drawerLayout);
-      if (!this.isLegacy) {
-        addStyle(STYLES.ASIDE, this.drawerLayout.shadowRoot);
-      }
+      addStyle(STYLES.ASIDE, this.drawerLayout.shadowRoot);
       if (queryString(OPTION.CACHE)) setCache(CACHE.SIDEBAR, TRUE);
     } else {
       removeStyle(this.drawerLayout);
-      if (!this.isLegacy) {
-        removeStyle(this.drawerLayout.shadowRoot);
-      }
+      removeStyle(this.drawerLayout.shadowRoot);
     }
 
     if (
@@ -479,9 +460,7 @@ class KioskMode implements KioskModeRunner {
     if (!this.menuTranslations) return;
 
     const getToolbarMenuItems = (): NodeListOf<HTMLElement> => {
-      return this.isLegacy
-        ? this.appToolbar.querySelectorAll<HTMLElement>(`:scope > ${ELEMENT.MENU_ITEM}`)
-        : this.appToolbar.querySelectorAll<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.MENU_ITEM}`);
+      return this.appToolbar.querySelectorAll<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.MENU_ITEM}`);
     };
 
     const getOverflowMenuItems = (): NodeListOf<HTMLElement> => this.appToolbar.querySelectorAll(ELEMENT.OVERLAY_MENU_ITEM);

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4,17 +4,19 @@ import {
     getDisplayNoneRulesString
 } from '@utilities';
 
-const APP_TOOLBAR = 'app-toolbar';
 const TOOLBAR = '.toolbar';
 const ACTION_ITEMS = '.action-items';
 const BUTTON_MENU = 'ha-button-menu';
 const OVERFLOW_BUTTON_MENU = 'mwc-list-item';
 
-const STYLES_COMMON = {
+export const STYLES = {
     HEADER: getCSSRulesString({
         '#view': {
           'min-height': '100vh !important',
           '--header-height': '0px'
+        },
+        '.header': {
+            'display': 'none'
         }
     }),
     ACCOUNT: getDisplayNoneRulesString('.profile'),
@@ -31,61 +33,6 @@ const STYLES_COMMON = {
           'right': '0',
           'top': '0',
           'z-index': '999999'
-        }
-    })
-};
-
-const STYLES_LEGACY = {
-    HEADER: getCSSRulesString({
-        'app-header': {
-            'display': 'none'
-        }
-    }),
-    SIDEBAR: getCSSRulesString({
-        ':host': {
-            '--app-drawer-width': '0 !important'
-        },
-        '#drawer': {
-            'display': 'none'
-        },
-    }),
-    OVERFLOW_MENU: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU}`
-    ),
-    OVERFLOW_MENU_EMPTY_DESKTOP: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="1"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="4"]`
-    ),
-    OVERFLOW_MENU_EMPTY_MOBILE: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="3"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="6"]`
-    ),
-    SEARCH: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.SEARCH}"]`
-    ),
-    ASSISTANT: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ha-icon-button[data-selector="${MENU.ASSIST}"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.ASSIST}"]`
-    ),
-    REFRESH: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.REFRESH}"]`
-    ),
-    UNUSED_ENTITIES: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.UNUSED_ENTITIES}"]`
-    ),
-    RELOAD_RESOURCES: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.RELOAD_RESOURCES}"]`
-    ),
-    EDIT_DASHBOARD: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.EDIT_DASHBOARD}"]`
-    )
-};
-
-const STYLES = {
-    HEADER: getCSSRulesString({
-        '.header': {
-            'display': 'none'
         }
     }),
     SIDEBAR: getCSSRulesString({
@@ -135,49 +82,4 @@ const STYLES = {
     EDIT_DASHBOARD: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.EDIT_DASHBOARD}"]`
     )
-};
-
-export const getStyles = (isLegacy: boolean) => {
-
-    // If it is legacy Home Assistant
-    if (isLegacy) {
-        return {
-            HEADER: `${STYLES_COMMON.HEADER}${STYLES_LEGACY.HEADER}`,
-            SIDEBAR: STYLES_LEGACY.SIDEBAR,
-            ASIDE: '',
-            ACCOUNT: STYLES_COMMON.ACCOUNT,
-            MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
-            MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
-            OVERFLOW_MENU: STYLES_LEGACY.OVERFLOW_MENU,
-            OVERFLOW_MENU_EMPTY_DESKTOP: STYLES_LEGACY.OVERFLOW_MENU_EMPTY_DESKTOP,
-            OVERFLOW_MENU_EMPTY_MOBILE: STYLES_LEGACY.OVERFLOW_MENU_EMPTY_MOBILE,
-            SEARCH: STYLES_LEGACY.SEARCH,
-            ASSISTANT: STYLES_LEGACY.ASSISTANT,
-            REFRESH: STYLES_LEGACY.REFRESH,
-            UNUSED_ENTITIES: STYLES_LEGACY.UNUSED_ENTITIES,
-            RELOAD_RESOURCES: STYLES_LEGACY.RELOAD_RESOURCES,
-            EDIT_DASHBOARD: STYLES_LEGACY.EDIT_DASHBOARD,
-            MOUSE: STYLES_COMMON.MOUSE
-        };
-    }
-
-    // Home Assistant >= 2023.4.x
-    return {
-        HEADER: `${STYLES_COMMON.HEADER}${STYLES.HEADER}`,
-        SIDEBAR: STYLES.SIDEBAR,
-        ASIDE: STYLES.ASIDE,
-        ACCOUNT: STYLES_COMMON.ACCOUNT,
-        MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
-        MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
-        OVERFLOW_MENU: STYLES.OVERFLOW_MENU,
-        OVERFLOW_MENU_EMPTY_DESKTOP: STYLES.OVERFLOW_MENU_EMPTY_DESKTOP,
-        OVERFLOW_MENU_EMPTY_MOBILE: STYLES.OVERFLOW_MENU_EMPTY_MOBILE,
-        SEARCH: STYLES.SEARCH,
-        ASSISTANT: STYLES.ASSISTANT,
-        REFRESH: STYLES.REFRESH,
-        UNUSED_ENTITIES: STYLES.UNUSED_ENTITIES,
-        RELOAD_RESOURCES: STYLES.RELOAD_RESOURCES,
-        EDIT_DASHBOARD: STYLES.EDIT_DASHBOARD,
-        MOUSE: STYLES_COMMON.MOUSE
-    };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,8 +2,6 @@ export interface KioskModeRunner {
     run: (lovelace: HTMLElement) => void;
 }
 
-export type Version = [number, number, string];
-
 export interface User {
     name: string;
     is_admin: boolean;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,6 @@
 import {
     HomeAssistant,
     StyleElement,
-    Version,
     Lovelace
 } from '@types';
 import {
@@ -136,29 +135,6 @@ export const getMenuTranslations = async(
         return [resourcesTranslated[prop], reference];
     });
     return Object.fromEntries(menuTranslationsEntries);
-};
-
-export const parseVersion = (version: string | undefined): Version | null => {
-    const versionRegExp = /^(\d+)\.(\d+)\.(\w+)(?:\.(\w+))?$/;
-    const match = version
-        ? version.match(versionRegExp)
-        : null;
-    if (match) {
-        return [
-            +match[1],
-            +match[2],
-            match[3]
-        ];
-    }
-    return null;
-};
-
-export const isLegacyVersion = (version: string | undefined): boolean => {
-    const parsedVersion = parseVersion(version);
-    if (parsedVersion) {
-        return parsedVersion[0] <= 2023 && parsedVersion[1] <= 3;
-    }
-    return false;
 };
 
 export const getMenuItems = (getElements: () => NodeListOf<HTMLElement>): Promise<NodeListOf<HTMLElement>> => {


### PR DESCRIPTION
When Home Assistant was updated to version `2023.4` it was a breaking change that required a lot of refactoring in the library. To help with the migration trasition, the old Home Assistant versions were supported in the code. Last Home Assistant version is `2023.5.4` and I tried the library in the version `2023.3.6` and it was failing:

>Uncaught (in promise) Error: Lovelace config not found. Giving up after 500 attempts.

As nobody has reported this issue, it seems that all the users of the library have already migrated to a newer version. For this reason, the support for Home Assistant `< 2023.4` is being removed in this pull request, as this logic just adds complexity to the code and make it harder to maintain and scalate.