### PR TITLE
Implement new hiding options

### DIFF
--- a/.hass/config/configuration.yaml
+++ b/.hass/config/configuration.yaml
@@ -55,7 +55,15 @@ lovelace:
     lovelace-overflow:
       mode: yaml
       title: Kiosk-mode hide overflow
-      filename: ui-lovelace-overflow.yaml  
+      filename: ui-lovelace-overflow.yaml
+    lovelace-overflow-list:
+      mode: yaml
+      title: Kiosk-mode hide overflow list
+      filename: ui-lovelace-overflow-list.yaml
+    lovelace-block-overflow:
+      mode: yaml
+      title: Kiosk-mode block overflow
+      filename: ui-lovelace-overflow-mouse.yaml
     lovelace-mouse:
       mode: yaml
       title: Kiosk-mode block mouse

--- a/.hass/config/inputs/booleans/kiosk-mode.yaml
+++ b/.hass/config/inputs/booleans/kiosk-mode.yaml
@@ -8,6 +8,8 @@ kiosk_hide_menubutton:
   name: Kiosk hide menu button
 kiosk_hide_overflow:
   name: Kiosk hide overflow
+kiosk_hide_overflow_list:
+  name: Kiosk hide overflow list
 kiosk_hide_account:
   name: Kiosk hide account
 kiosk_hide_search:
@@ -22,7 +24,7 @@ kiosk_hide_reload_resources:
   name: Kiosk hide reload resources
 kiosk_hide_edit_dashboard:
   name: Kiosk hide edit dashboard
-kiosk_auto_hide_overflow:
-  name: Kiosk auto hide overflow
+kiosk_block_overflow:
+  name: Kiosk block overflow
 kiosk_block_mouse:
   name: Kiosk block mouse

--- a/.hass/config/ui-lovelace-overflow-list.yaml
+++ b/.hass/config/ui-lovelace-overflow-list.yaml
@@ -1,0 +1,11 @@
+kiosk_mode:
+  hide_overflow_list: true
+title: Kiosk-mode hide overflow list
+views:
+  - theme: Backend-selected
+    title: Hide Overflow List
+    path: kiosk-mode-hide-overflow-list
+    badges: []
+    cards:
+      - type: markdown
+        content: This dashboard has the setting `hide_overflow_list` on `true`. The overflow menu is located at the right of the header (three-dots button) and the overflow list is the list that opens when one clicks on the overflow menu.

--- a/.hass/config/ui-lovelace-overflow-mouse.yaml
+++ b/.hass/config/ui-lovelace-overflow-mouse.yaml
@@ -1,0 +1,11 @@
+kiosk_mode:
+  block_overflow: true
+title: Kiosk-mode block overflow
+views:
+  - theme: Backend-selected
+    title: Block Overflow
+    path: kiosk-mode-block-overflow
+    badges: []
+    cards:
+      - type: markdown
+        content: This dashboard has the setting `block_overflow` on `true`. You cannot interact with the overflow menu if this option is enabled.  The overflow menu is located at the right of the header (three-dots button).

--- a/.hass/config/ui-lovelace.yaml
+++ b/.hass/config/ui-lovelace.yaml
@@ -34,11 +34,14 @@ kiosk_mode:
         input_boolean.kiosk_hide_edit_dashboard: 'on'
       hide_edit_dashboard: true
     - entity:
-        input_boolean.kiosk_auto_hide_overflow: 'on'
-      auto_hide_overflow: true
-    - entity:
         input_boolean.kiosk_hide_overflow: 'on'
       hide_overflow: true
+    - entity:
+        input_boolean.kiosk_hide_overflow_list: 'on'
+      hide_overflow_list: true
+    - entity:
+        input_boolean.kiosk_block_overflow: 'on'
+      block_overflow: true
     - entity:
         input_boolean.kiosk_block_mouse: 'on'
       block_mouse: true
@@ -60,9 +63,10 @@ views:
           - entity: input_boolean.kiosk_hide_search
           - entity: input_boolean.kiosk_hide_assistant
           - entity: input_boolean.kiosk_hide_overflow
+          - entity: input_boolean.kiosk_hide_overflow_list
           - entity: input_boolean.kiosk_hide_refresh
           - entity: input_boolean.kiosk_hide_unused_entities
           - entity: input_boolean.kiosk_hide_reload_resources
           - entity: input_boolean.kiosk_hide_edit_dashboard
-          - entity: input_boolean.kiosk_auto_hide_overflow
+          - entity: input_boolean.kiosk_block_overflow
           - entity: input_boolean.kiosk_block_mouse

--- a/README.md
+++ b/README.md
@@ -76,15 +76,16 @@ views:
 |`hide_header:`\*          | Boolean | false   | Hides only the header. |
 |`hide_sidebar:`           | Boolean | false   | Hides only the sidebar. |
 |`hide_menubutton:`\*      | Boolean | false   | Hides only the sidebar menu icon. |
-|`hide_overflow:`          | Boolean | false   | Hides the top right menu. |
+|`hide_overflow:`          | Boolean | false   | Hides the top right overflow menu. |
+|`hide_overflow_list`      | Boolean | false   | Hides the top right overflow menu list |
 |`hide_account:`           | Boolean | false   | Hides the account icon. |
 |`hide_search:`            | Boolean | false   | Hides the search icon. |
 |`hide_assistant:`         | Boolean | false   | Hides the assistant icon. |
-|`hide_edit_dashboard`     | Boolean | false   | Hides the "Edit dashboard" button inside the top right menu |
-|`hide_refresh`            | Boolean | false   | Hides the "Refresh" button inside the top right menu in lovelace yaml mode |
-|`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right menu in lovelace yaml mode |
-|`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right menu in lovelace yaml mode |
-|`auto_hide_overflow`      | Boolean | false   | Hides automatically the top right menu if all its items have been hidden |
+|`hide_edit_dashboard`     | Boolean | false   | Hides the "Edit dashboard" button inside the top right overflow menu |
+|`hide_refresh`            | Boolean | false   | Hides the "Refresh" button inside the top right overflow menu in lovelace yaml mode |
+|`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right overflow menu in lovelace yaml mode |
+|`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right overflow menu in lovelace yaml mode |
+|`block_overflow`          | Boolean | false   | Blocks the top right overflow menu mouse interactions |
 |`block_mouse:`            | Boolean | false   | Blocks completely the mouse. No interaction is allowed and the mouse will not be visible. **Can only be disabled with `?disable_km` query parameter in the URL.** |
 |`ignore_entity_settings:`\** | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
 |`ignore_mobile_settings:`\*\*\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
@@ -203,6 +204,7 @@ The query string options are:
 * `?hide_header` to hide only the header
 * `?hide_sidebar` to hide only the sidebar
 * `?hide_overflow` to hide the top right menu
+* `?hide_overflow_list` to hide the top right overflow menu list
 * `?hide_menubutton` to hide sidebar menu button
 * `?hide_account` to hide the account icon
 * `?hide_search` to hide the search icon
@@ -211,7 +213,7 @@ The query string options are:
 * `?hide_refresh` to hide the "Refresh" button inside the top right menu in lovelace yaml mode
 * `?hide_unused_entities` to hide the "Unused entities" button inside the top right menu in lovelace yaml mode
 * `?hide_reload_resources` to hide the "Reload resources" button inside the top right menu in lovelace yaml mode
-* `?auto_hide_overflow` to hide automatically the top right menu if all its items have been hidden
+* `?block_overflow` to block the top right overflow menu mouse interactions
 * `?block_mouse` to block completely the mouse
 
 ## Query String Caching

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,6 +5,7 @@ export enum CACHE {
     HEADER = 'kmHeader',
     SIDEBAR = 'kmSidebar',
     OVERFLOW = 'kmOverflow',
+    OVERFLOW_LIST = 'kmOverflowList',
     MENU_BUTTON = 'kmMenuButton',
     ACCOUNT = 'kmAccount',
     SEARCH = 'kmSearch',
@@ -13,7 +14,7 @@ export enum CACHE {
     UNUSED_ENTITIES = 'kmUnusedEntities',
     RELOAD_RESOURCES = 'kmReloadResources',
     EDIT_DASHBOARD = 'kmEditDashboard',
-    AUTO_HIDE_OVERFLOW = 'kmAutoHideOverflow',
+    OVERFLOW_MOUSE = 'kmOverflowMouse',
     MOUSE = 'kmMouse'
 }
 
@@ -25,6 +26,7 @@ export enum OPTION {
     HIDE_SIDEBAR = 'hide_sidebar',
     HIDE_HEADER = 'hide_header',
     HIDE_OVERFLOW = 'hide_overflow',
+    HIDE_OVERFLOW_LIST = 'hide_overflow_list',
     HIDE_MENU_BUTTON = 'hide_menubutton',
     HIDE_ACCOUNT = 'hide_account',
     HIDE_SEARCH = 'hide_search',
@@ -33,7 +35,7 @@ export enum OPTION {
     HIDE_UNUSED_ENTITIES = 'hide_unused_entities',
     HIDE_RELOAD_RESOURCES = 'hide_reload_resources',
     HIDE_EDIT_DASHBOARD = 'hide_edit_dashboard',
-    AUTO_HIDE_OVERFLOW = 'auto_hide_overflow',
+    BLOCK_OVERFLOW = 'block_overflow',
     BLOCK_MOUSE = 'block_mouse'
 }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -77,11 +77,7 @@ export enum ELEMENT {
     MENU_ITEM_ICON = 'mwc-icon-button',
     OVERLAY_MENU = 'ha-button-menu',
     OVERLAY_MENU_ITEM = 'mwc-list-item',
-    APP_DRAWER_LAYOUT = 'app-drawer-layout',
-    APP_TOOLBAR = 'app-toolbar',
-    APP_DRAWER = 'app-drawer',
     HA_SIDEBAR = 'ha-sidebar',
-    // Home Assistant 2023.4
     HA_DRAWER = 'ha-drawer',
     TOOLBAR = '.toolbar',
     ACTION_ITEMS = '.action-items'

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -23,7 +23,6 @@ import {
   NAMESPACE
 } from '@constants';
 import {
-  isLegacyVersion,
   toArray,
   queryString,
   setCache,
@@ -34,7 +33,7 @@ import {
   getMenuTranslations,
   getMenuItems
 } from '@utilities';
-import { getStyles } from '@styles';
+import { STYLES } from '@styles';
 
 import { ConInfo } from './conf-info';
 
@@ -61,7 +60,6 @@ class KioskMode implements KioskModeRunner {
     this.ha = document.querySelector<HomeAssistant>(ELEMENT.HOME_ASSISTANT);
     this.main = this.ha.shadowRoot.querySelector(ELEMENT.HOME_ASSISTANT_MAIN).shadowRoot;
     this.user = this.ha.hass.user;
-    this.isLegacy = isLegacyVersion(this.ha.hass?.config?.version);
     this.resizeWindowBinded = this.resizeWindow.bind(this);
     this.run();
     this.entityWatch();
@@ -74,7 +72,6 @@ class KioskMode implements KioskModeRunner {
   // Elements
   private ha: HomeAssistant;
   private main: ShadowRoot;
-  private isLegacy: boolean;
   private user: User;
   private huiRoot: ShadowRoot;
   private lovelace: Lovelace;
@@ -157,20 +154,10 @@ class KioskMode implements KioskModeRunner {
     this.mode = this.lovelace?.lovelace?.mode || LOVELACE_MODE.STORAGE;
     this.huiRoot = this.lovelace.shadowRoot.querySelector(ELEMENT.HUI_ROOT).shadowRoot;
 
-    if (this.isLegacy) {
-      // Legacy Home Assistant
-      this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.APP_DRAWER_LAYOUT);
-      this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.APP_TOOLBAR);
-      const appDrawer = this.drawerLayout.querySelector(ELEMENT.APP_DRAWER);
-      this.sideBarRoot = appDrawer.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
-      this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.OVERLAY_MENU}`);
-    } else {
-      // Home Assistant >= 2023.4.x
-      this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.HA_DRAWER);
-      this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.TOOLBAR);
-      this.sideBarRoot = this.drawerLayout.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
-      this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.OVERLAY_MENU}`);
-    }
+    this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.HA_DRAWER);
+    this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.TOOLBAR);
+    this.sideBarRoot = this.drawerLayout.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
+    this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.OVERLAY_MENU}`);
 
     // Retrieve localStorage values & query string options.
     const queryStringsSet = (
@@ -334,9 +321,7 @@ class KioskMode implements KioskModeRunner {
     this.insertStyles();
   }
 
-  protected insertStyles() {  
-    
-    const STYLES = getStyles(this.isLegacy);
+  protected insertStyles() {
   
     if (this.hideHeader) {
       addStyle(STYLES.HEADER, this.huiRoot);
@@ -347,15 +332,11 @@ class KioskMode implements KioskModeRunner {
 
     if (this.hideSidebar) {
       addStyle(STYLES.SIDEBAR, this.drawerLayout);
-      if (!this.isLegacy) {
-        addStyle(STYLES.ASIDE, this.drawerLayout.shadowRoot);
-      }
+      addStyle(STYLES.ASIDE, this.drawerLayout.shadowRoot);
       if (queryString(OPTION.CACHE)) setCache(CACHE.SIDEBAR, TRUE);
     } else {
       removeStyle(this.drawerLayout);
-      if (!this.isLegacy) {
-        removeStyle(this.drawerLayout.shadowRoot);
-      }
+      removeStyle(this.drawerLayout.shadowRoot);
     }
 
     if (
@@ -479,9 +460,7 @@ class KioskMode implements KioskModeRunner {
     if (!this.menuTranslations) return;
 
     const getToolbarMenuItems = (): NodeListOf<HTMLElement> => {
-      return this.isLegacy
-        ? this.appToolbar.querySelectorAll<HTMLElement>(`:scope > ${ELEMENT.MENU_ITEM}`)
-        : this.appToolbar.querySelectorAll<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.MENU_ITEM}`);
+      return this.appToolbar.querySelectorAll<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.MENU_ITEM}`);
     };
 
     const getOverflowMenuItems = (): NodeListOf<HTMLElement> => this.appToolbar.querySelectorAll(ELEMENT.OVERLAY_MENU_ITEM);

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,4 +1,4 @@
-import { MENU, LOVELACE_MODE } from '@constants';
+import { MENU } from '@constants';
 import {
     getCSSRulesString,
     getDisplayNoneRulesString
@@ -54,14 +54,12 @@ export const STYLES = {
     OVERFLOW_MENU: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}`
     ),
-    OVERFLOW_MENU_EMPTY_DESKTOP: getDisplayNoneRulesString(
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="1"]`,
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="4"]`
-    ),
-    OVERFLOW_MENU_EMPTY_MOBILE: getDisplayNoneRulesString(
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="3"]`,
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="6"]`
-    ),
+    OVERFLOW_MENU_LIST: getDisplayNoneRulesString('mwc-menu'),
+    BLOCK_OVERFLOW: getCSSRulesString({
+        [`${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}`]: {
+            'pointer-events': 'none !important'
+        }
+    }),
     SEARCH: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.SEARCH}"]`

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4,17 +4,19 @@ import {
     getDisplayNoneRulesString
 } from '@utilities';
 
-const APP_TOOLBAR = 'app-toolbar';
 const TOOLBAR = '.toolbar';
 const ACTION_ITEMS = '.action-items';
 const BUTTON_MENU = 'ha-button-menu';
 const OVERFLOW_BUTTON_MENU = 'mwc-list-item';
 
-const STYLES_COMMON = {
+export const STYLES = {
     HEADER: getCSSRulesString({
         '#view': {
           'min-height': '100vh !important',
           '--header-height': '0px'
+        },
+        '.header': {
+            'display': 'none'
         }
     }),
     ACCOUNT: getDisplayNoneRulesString('.profile'),
@@ -31,61 +33,6 @@ const STYLES_COMMON = {
           'right': '0',
           'top': '0',
           'z-index': '999999'
-        }
-    })
-};
-
-const STYLES_LEGACY = {
-    HEADER: getCSSRulesString({
-        'app-header': {
-            'display': 'none'
-        }
-    }),
-    SIDEBAR: getCSSRulesString({
-        ':host': {
-            '--app-drawer-width': '0 !important'
-        },
-        '#drawer': {
-            'display': 'none'
-        },
-    }),
-    OVERFLOW_MENU: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU}`
-    ),
-    OVERFLOW_MENU_EMPTY_DESKTOP: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="1"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="4"]`
-    ),
-    OVERFLOW_MENU_EMPTY_MOBILE: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="3"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="6"]`
-    ),
-    SEARCH: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.SEARCH}"]`
-    ),
-    ASSISTANT: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ha-icon-button[data-selector="${MENU.ASSIST}"]`,
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.ASSIST}"]`
-    ),
-    REFRESH: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.REFRESH}"]`
-    ),
-    UNUSED_ENTITIES: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.UNUSED_ENTITIES}"]`
-    ),
-    RELOAD_RESOURCES: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.RELOAD_RESOURCES}"]`
-    ),
-    EDIT_DASHBOARD: getDisplayNoneRulesString(
-        `${APP_TOOLBAR} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.EDIT_DASHBOARD}"]`
-    )
-};
-
-const STYLES = {
-    HEADER: getCSSRulesString({
-        '.header': {
-            'display': 'none'
         }
     }),
     SIDEBAR: getCSSRulesString({
@@ -135,49 +82,4 @@ const STYLES = {
     EDIT_DASHBOARD: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.EDIT_DASHBOARD}"]`
     )
-};
-
-export const getStyles = (isLegacy: boolean) => {
-
-    // If it is legacy Home Assistant
-    if (isLegacy) {
-        return {
-            HEADER: `${STYLES_COMMON.HEADER}${STYLES_LEGACY.HEADER}`,
-            SIDEBAR: STYLES_LEGACY.SIDEBAR,
-            ASIDE: '',
-            ACCOUNT: STYLES_COMMON.ACCOUNT,
-            MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
-            MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
-            OVERFLOW_MENU: STYLES_LEGACY.OVERFLOW_MENU,
-            OVERFLOW_MENU_EMPTY_DESKTOP: STYLES_LEGACY.OVERFLOW_MENU_EMPTY_DESKTOP,
-            OVERFLOW_MENU_EMPTY_MOBILE: STYLES_LEGACY.OVERFLOW_MENU_EMPTY_MOBILE,
-            SEARCH: STYLES_LEGACY.SEARCH,
-            ASSISTANT: STYLES_LEGACY.ASSISTANT,
-            REFRESH: STYLES_LEGACY.REFRESH,
-            UNUSED_ENTITIES: STYLES_LEGACY.UNUSED_ENTITIES,
-            RELOAD_RESOURCES: STYLES_LEGACY.RELOAD_RESOURCES,
-            EDIT_DASHBOARD: STYLES_LEGACY.EDIT_DASHBOARD,
-            MOUSE: STYLES_COMMON.MOUSE
-        };
-    }
-
-    // Home Assistant >= 2023.4.x
-    return {
-        HEADER: `${STYLES_COMMON.HEADER}${STYLES.HEADER}`,
-        SIDEBAR: STYLES.SIDEBAR,
-        ASIDE: STYLES.ASIDE,
-        ACCOUNT: STYLES_COMMON.ACCOUNT,
-        MENU_BUTTON: STYLES_COMMON.MENU_BUTTON,
-        MENU_BUTTON_BURGER: STYLES_COMMON.MENU_BUTTON_BURGER,
-        OVERFLOW_MENU: STYLES.OVERFLOW_MENU,
-        OVERFLOW_MENU_EMPTY_DESKTOP: STYLES.OVERFLOW_MENU_EMPTY_DESKTOP,
-        OVERFLOW_MENU_EMPTY_MOBILE: STYLES.OVERFLOW_MENU_EMPTY_MOBILE,
-        SEARCH: STYLES.SEARCH,
-        ASSISTANT: STYLES.ASSISTANT,
-        REFRESH: STYLES.REFRESH,
-        UNUSED_ENTITIES: STYLES.UNUSED_ENTITIES,
-        RELOAD_RESOURCES: STYLES.RELOAD_RESOURCES,
-        EDIT_DASHBOARD: STYLES.EDIT_DASHBOARD,
-        MOUSE: STYLES_COMMON.MOUSE
-    };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,8 +2,6 @@ export interface KioskModeRunner {
     run: (lovelace: HTMLElement) => void;
 }
 
-export type Version = [number, number, string];
-
 export interface User {
     name: string;
     is_admin: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface KioskConfig {
     hide_header?: boolean;
     hide_sidebar?: boolean;
     hide_overflow?: boolean;
+    hide_overflow_list?: boolean;
     hide_menubutton?: boolean;
     hide_account?: boolean;
     hide_search?: boolean;
@@ -35,7 +36,7 @@ export interface KioskConfig {
     hide_unused_entities?: boolean;
     hide_reload_resources?: boolean;
     hide_edit_dashboard?: boolean;
-    auto_hide_overflow?: boolean;
+    block_overflow?: boolean;
     block_mouse?: boolean;
     admin_settings?: ConditionalKioskConfig;
     non_admin_settings?: ConditionalKioskConfig;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,6 @@
 import {
     HomeAssistant,
     StyleElement,
-    Version,
     Lovelace
 } from '@types';
 import {
@@ -136,29 +135,6 @@ export const getMenuTranslations = async(
         return [resourcesTranslated[prop], reference];
     });
     return Object.fromEntries(menuTranslationsEntries);
-};
-
-export const parseVersion = (version: string | undefined): Version | null => {
-    const versionRegExp = /^(\d+)\.(\d+)\.(\w+)(?:\.(\w+))?$/;
-    const match = version
-        ? version.match(versionRegExp)
-        : null;
-    if (match) {
-        return [
-            +match[1],
-            +match[2],
-            match[3]
-        ];
-    }
-    return null;
-};
-
-export const isLegacyVersion = (version: string | undefined): boolean => {
-    const parsedVersion = parseVersion(version);
-    if (parsedVersion) {
-        return parsedVersion[0] <= 2023 && parsedVersion[1] <= 3;
-    }
-    return false;
 };
 
 export const getMenuItems = (getElements: () => NodeListOf<HTMLElement>): Promise<NodeListOf<HTMLElement>> => {


### PR DESCRIPTION
This pull request removes the `auto_hide_overflow` option and implements two new options that will give more control over the elements that should be hidden in Home Assistant. `auto_hide_overflow` is a confusing option because it is not clear what it does by its name, if one enables it, most of the time one will not notice any change in the interface just because it needs several options enabled to work. This has been fixed replacing it by two other options that can achieve together what this option wanted to achieve.

## Config Options

| Config Option            | Type    | Default | Description |
|:-------------------------|:--------|:--------|:------------|
|`hide_overflow_list`      | Boolean | false   | Hides the top right overflow menu list |
|`block_overflow`          | Boolean | false   | Blocks the top right overflow menu mouse interactions |

## Query Strings

* `?hide_overflow_list` to hide the top right overflow menu list
* `?block_overflow` to block the top right overflow menu mouse interactions

>Note: This pull request depends on https://github.com/NemesisRE/kiosk-mode/pull/85 to get merged. Once https://github.com/NemesisRE/kiosk-mode/pull/85 gets merged, this branch should be rebased and updated before merging it.
