### PR TITLE
Implement a block_overflow option and remove the auto_hide_overflow one

### DIFF
--- a/.hass/config/configuration.yaml
+++ b/.hass/config/configuration.yaml
@@ -55,7 +55,11 @@ lovelace:
     lovelace-overflow:
       mode: yaml
       title: Kiosk-mode hide overflow
-      filename: ui-lovelace-overflow.yaml  
+      filename: ui-lovelace-overflow.yaml
+    lovelace-block-overflow:
+      mode: yaml
+      title: Kiosk-mode block overflow
+      filename: ui-lovelace-overflow-mouse.yaml
     lovelace-mouse:
       mode: yaml
       title: Kiosk-mode block mouse

--- a/.hass/config/inputs/booleans/kiosk-mode.yaml
+++ b/.hass/config/inputs/booleans/kiosk-mode.yaml
@@ -22,7 +22,7 @@ kiosk_hide_reload_resources:
   name: Kiosk hide reload resources
 kiosk_hide_edit_dashboard:
   name: Kiosk hide edit dashboard
-kiosk_auto_hide_overflow:
-  name: Kiosk auto hide overflow
+kiosk_block_overflow:
+  name: Kiosk block overflow
 kiosk_block_mouse:
   name: Kiosk block mouse

--- a/.hass/config/ui-lovelace-overflow-mouse.yaml
+++ b/.hass/config/ui-lovelace-overflow-mouse.yaml
@@ -1,0 +1,11 @@
+kiosk_mode:
+  block_overflow: true
+title: Kiosk-mode block overflow
+views:
+  - theme: Backend-selected
+    title: Block Overflow
+    path: kiosk-mode-block-overflow
+    badges: []
+    cards:
+      - type: markdown
+        content: This dashboard has the setting `block_overflow` on `true`. You cannot interact with the overflow menu if this option is enabled.  The overflow menu is located at the right of the header (three-dots button).

--- a/.hass/config/ui-lovelace.yaml
+++ b/.hass/config/ui-lovelace.yaml
@@ -34,11 +34,11 @@ kiosk_mode:
         input_boolean.kiosk_hide_edit_dashboard: 'on'
       hide_edit_dashboard: true
     - entity:
-        input_boolean.kiosk_auto_hide_overflow: 'on'
-      auto_hide_overflow: true
-    - entity:
         input_boolean.kiosk_hide_overflow: 'on'
       hide_overflow: true
+    - entity:
+        input_boolean.kiosk_block_overflow: 'on'
+      block_overflow: true
     - entity:
         input_boolean.kiosk_block_mouse: 'on'
       block_mouse: true
@@ -64,5 +64,5 @@ views:
           - entity: input_boolean.kiosk_hide_unused_entities
           - entity: input_boolean.kiosk_hide_reload_resources
           - entity: input_boolean.kiosk_hide_edit_dashboard
-          - entity: input_boolean.kiosk_auto_hide_overflow
+          - entity: input_boolean.kiosk_block_overflow
           - entity: input_boolean.kiosk_block_mouse

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ views:
 |`hide_header:`\*          | Boolean | false   | Hides only the header. |
 |`hide_sidebar:`           | Boolean | false   | Hides only the sidebar. |
 |`hide_menubutton:`\*      | Boolean | false   | Hides only the sidebar menu icon. |
-|`hide_overflow:`          | Boolean | false   | Hides the top right menu. |
+|`hide_overflow:`          | Boolean | false   | Hides the top right overflow menu. |
 |`hide_account:`           | Boolean | false   | Hides the account icon. |
 |`hide_search:`            | Boolean | false   | Hides the search icon. |
 |`hide_assistant:`         | Boolean | false   | Hides the assistant icon. |
-|`hide_edit_dashboard`     | Boolean | false   | Hides the "Edit dashboard" button inside the top right menu |
-|`hide_refresh`            | Boolean | false   | Hides the "Refresh" button inside the top right menu in lovelace yaml mode |
-|`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right menu in lovelace yaml mode |
-|`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right menu in lovelace yaml mode |
-|`auto_hide_overflow`      | Boolean | false   | Hides automatically the top right menu if all its items have been hidden |
+|`hide_edit_dashboard`     | Boolean | false   | Hides the "Edit dashboard" button inside the top right overflow menu |
+|`hide_refresh`            | Boolean | false   | Hides the "Refresh" button inside the top right overflow menu in lovelace yaml mode |
+|`hide_unused_entities`    | Boolean | false   | Hides the "Unused entities" button inside the top right overflow menu in lovelace yaml mode |
+|`hide_reload_resources`   | Boolean | false   | Hides the "Reload resources" button inside the top right overflow menu in lovelace yaml mode |
+|`block_overflow`          | Boolean | false   | Blocks the top right overflow menu mouse interactions |
 |`block_mouse:`            | Boolean | false   | Blocks completely the mouse. No interaction is allowed and the mouse will not be visible. **Can only be disabled with `?disable_km` query parameter in the URL.** |
 |`ignore_entity_settings:`\** | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `entity_settings` to be ignored. |
 |`ignore_mobile_settings:`\*\*\* | Boolean | false   | Useful for [conditional configs](#conditional-lovelace-config) and will cause `mobile_settings` to be ignored. |
@@ -211,7 +211,7 @@ The query string options are:
 * `?hide_refresh` to hide the "Refresh" button inside the top right menu in lovelace yaml mode
 * `?hide_unused_entities` to hide the "Unused entities" button inside the top right menu in lovelace yaml mode
 * `?hide_reload_resources` to hide the "Reload resources" button inside the top right menu in lovelace yaml mode
-* `?auto_hide_overflow` to hide automatically the top right menu if all its items have been hidden
+* `?block_overflow` to block the top right overflow menu mouse interactions
 * `?block_mouse` to block completely the mouse
 
 ## Query String Caching

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,7 +13,7 @@ export enum CACHE {
     UNUSED_ENTITIES = 'kmUnusedEntities',
     RELOAD_RESOURCES = 'kmReloadResources',
     EDIT_DASHBOARD = 'kmEditDashboard',
-    AUTO_HIDE_OVERFLOW = 'kmAutoHideOverflow',
+    OVERFLOW_MOUSE = 'kmOverflowMouse',
     MOUSE = 'kmMouse'
 }
 
@@ -33,7 +33,7 @@ export enum OPTION {
     HIDE_UNUSED_ENTITIES = 'hide_unused_entities',
     HIDE_RELOAD_RESOURCES = 'hide_reload_resources',
     HIDE_EDIT_DASHBOARD = 'hide_edit_dashboard',
-    AUTO_HIDE_OVERFLOW = 'auto_hide_overflow',
+    BLOCK_OVERFLOW = 'block_overflow',
     BLOCK_MOUSE = 'block_mouse'
 }
 
@@ -50,11 +50,6 @@ export enum MENU {
     UNUSED_ENTITIES = 'UNUSED_ENTITIES',
     RELOAD_RESOURCES = 'RELOAD_RESOURCES',
     EDIT_DASHBOARD = 'EDIT_DASHBOARD'
-}
-
-export enum LOVELACE_MODE {
-    STORAGE = 'storage',
-    YAML = 'yaml'
 }
 
 export const MENU_REFERENCES = Object.freeze({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -70,7 +70,6 @@ export enum ELEMENT {
     HUI_VIEW = 'hui-view',
     MENU_ITEM = 'ha-icon-button',
     MENU_ITEM_ICON = 'mwc-icon-button',
-    OVERLAY_MENU = 'ha-button-menu',
     OVERLAY_MENU_ITEM = 'mwc-list-item',
     HA_SIDEBAR = 'ha-sidebar',
     HA_DRAWER = 'ha-drawer',

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -77,8 +77,6 @@ class KioskMode implements KioskModeRunner {
   private drawerLayout: HTMLElement;
   private appToolbar: HTMLElement;
   private sideBarRoot: ShadowRoot;
-  private overlayMenu: HTMLElement;
-  private overlayMenuRoot: ShadowRoot;
   private menuTranslations: Record<string, string>;
   private resizeDelay: number;
   private resizeWindowBinded: () => void;
@@ -155,7 +153,6 @@ class KioskMode implements KioskModeRunner {
     this.drawerLayout = this.main.querySelector<HTMLElement>(ELEMENT.HA_DRAWER);
     this.appToolbar = this.huiRoot.querySelector<HTMLElement>(ELEMENT.TOOLBAR);
     this.sideBarRoot = this.drawerLayout.querySelector(ELEMENT.HA_SIDEBAR).shadowRoot;
-    this.overlayMenu = this.appToolbar.querySelector<HTMLElement>(`:scope > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.OVERLAY_MENU}`);
 
     // Retrieve localStorage values & query string options.
     const queryStringsSet = (

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,4 +1,4 @@
-import { MENU, LOVELACE_MODE } from '@constants';
+import { MENU } from '@constants';
 import {
     getCSSRulesString,
     getDisplayNoneRulesString
@@ -54,14 +54,11 @@ export const STYLES = {
     OVERFLOW_MENU: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}`
     ),
-    OVERFLOW_MENU_EMPTY_DESKTOP: getDisplayNoneRulesString(
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="1"]`,
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="4"]`
-    ),
-    OVERFLOW_MENU_EMPTY_MOBILE: getDisplayNoneRulesString(
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.STORAGE}][data-children="3"]`,
-        `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}[data-lovelace-mode=${LOVELACE_MODE.YAML}][data-children="6"]`
-    ),
+    BLOCK_OVERFLOW: getCSSRulesString({
+        [`${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU}`]: {
+            'pointer-events': 'none !important'
+        }
+    }),
     SEARCH: getDisplayNoneRulesString(
         `${TOOLBAR} > ${ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
         `${TOOLBAR} > ${ACTION_ITEMS} > ${BUTTON_MENU} > ${OVERFLOW_BUTTON_MENU}[data-selector="${MENU.SEARCH}"]`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,7 @@ export interface KioskConfig {
     hide_unused_entities?: boolean;
     hide_reload_resources?: boolean;
     hide_edit_dashboard?: boolean;
-    auto_hide_overflow?: boolean;
+    block_overflow?: boolean;
     block_mouse?: boolean;
     admin_settings?: ConditionalKioskConfig;
     non_admin_settings?: ConditionalKioskConfig;


### PR DESCRIPTION
This pull request removes the `auto_hide_overflow` option and implements a new option that will give more control and avoids confusion. `auto_hide_overflow` is a confusing option because it is not clear what it does by its name, if one enables it, most of the time one will not notice any change in the interface just because it needs several options enabled to work. This has been fixed replacing it by another option that can block the overflow from mouse interactions without hidding it (if one wants to hide it, the `hide_overflow` option is available). Making the overflow gets hidden if some of the options are enabled is something thay could be achieved using Home Assistant binary sensor feature and it is something that should not be in the logic of the plugin. This removes a lot of code that would likely break in future Home Assistant versions and it also removes any confusion that the previous option could generate.

## Config Options

| Config Option            | Type    | Default | Description |
|:-------------------------|:--------|:--------|:------------|
|`block_overflow`          | Boolean | false   | Blocks the top right overflow menu mouse interactions |

## Query Strings

* `?block_overflow` to block the top right overflow menu mouse interactions

>Note: This pull request depends on https://github.com/NemesisRE/kiosk-mode/pull/85 to get merged. Once https://github.com/NemesisRE/kiosk-mode/pull/85 gets merged, this branch should be rebased and updated before merging it.
