### PR TITLE
Block menu gestures when the sidebar is hidden

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -149,6 +149,7 @@ export const FALSE = 'false';
 export const CUSTOM_MOBILE_WIDTH_DEFAULT = 812;
 export const SUSCRIBE_EVENTS_TYPE = 'subscribe_events';
 export const STATE_CHANGED_EVENT = 'state_changed';
+export const TOGGLE_MENU_EVENT = 'hass-toggle-menu';
 export const MAX_ATTEMPTS = 500;
 export const RETRY_DELAY = 50;
 export const WINDOW_RESIZE_DELAY = 250;

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -18,6 +18,7 @@ import {
   CUSTOM_MOBILE_WIDTH_DEFAULT,
   SUSCRIBE_EVENTS_TYPE,
   STATE_CHANGED_EVENT,
+  TOGGLE_MENU_EVENT,
   WINDOW_RESIZE_DELAY,
   NAMESPACE,
   NON_CRITICAL_WARNING,
@@ -495,6 +496,13 @@ class KioskMode implements KioskModeRunner {
 
   // INSERT REGULAR STYLES
   protected insertStyles() {
+
+    // Remove toggle menu event
+    this.main?.host?.removeEventListener(TOGGLE_MENU_EVENT, this.blockToggleMenuGesture, true);
+
+    if (this.hideSidebar) {
+      this.main?.host?.addEventListener(TOGGLE_MENU_EVENT, this.blockToggleMenuGesture, true);
+    }
   
     if (this.hideHeader) {
       addStyle(STYLES.HEADER, this.huiRoot);
@@ -902,6 +910,11 @@ class KioskMode implements KioskModeRunner {
         .runDialogs()
         .catch(() => { /* ignore if it doesn‘t exist */ });
     }
+  }
+
+  protected blockToggleMenuGesture(event: Event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
   }
 
   protected setOptions(config: ConditionalKioskConfig, conditional: boolean) {


### PR DESCRIPTION
This pull request introduces a workaround to avoid blocking the Home Assistant view on IOS devices when swipping from the left with the sidebar hidden by `kiosk-mode`.

>Note: This change is just a patch, it doesn‘t introduce any breaking changes, so it is retro-compatible.

Closes: #112 