### PR TITLE
Improve the styles to move the header to the bottom in the kiosk-mode complements

### DIFF
--- a/KIOSK-MODE-COMPLEMENTS.md
+++ b/KIOSK-MODE-COMPLEMENTS.md
@@ -13,15 +13,21 @@ This method moves the main Home Assistant header from the top to the bottom of t
 ```yaml
 your-custom-theme:
   card-mod-theme: your-custom-theme
-  card-mod-root: |
-    .header {
-      bottom: 0;
-      top: auto !important;
-    }
-    #view {
-      padding-bottom: calc(var(--header-height) + env(safe-area-inset-top)) !important;
-      padding-top: 0 !important;
-    }
+  card-mod-root-yaml: |
+    .: | 
+      .header {
+        bottom: 0;
+        top: auto !important;
+      }
+      #view {
+        padding-bottom: calc(var(--header-height) + env(safe-area-inset-top)) !important;
+        padding-top: 0 !important;
+      }
+    ha-tabs$: |
+      #selectionBar {
+        bottom: auto;
+        top: 0;
+      }
 ```
 
 ### Cards


### PR DESCRIPTION
This pull request improves the styles necessary to move the header to the bottom in the kiosk-mode complements documentation, moving also the `selectionBar` element to the top of the header.