### PR TITLE
Refactor options management

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,44 +3,8 @@ export const STYLES_PREFIX = 'kiosk_mode';
 export const NON_CRITICAL_WARNING = '[ Non critial warning ]';
 export const SHADOW_ROOT_SUFFIX = ':shadowRoot';
 
-export enum CACHE {
-    HEADER = 'kmHeader',
-    SIDEBAR = 'kmSidebar',
-    OVERFLOW = 'kmOverflow',
-    MENU_BUTTON = 'kmMenuButton',
-    ACCOUNT = 'kmAccount',
-    NOTIFICATIONS = 'kmNotifications',
-    SEARCH = 'kmSearch',
-    ASSISTANT = 'kmAssistant',
-    REFRESH = 'kmRefresh',
-    UNUSED_ENTITIES = 'kmUnusedEntities',
-    RELOAD_RESOURCES = 'kmReloadResources',
-    EDIT_DASHBOARD = 'kmEditDashboard',
-    DIALOG_HEADER_ACTION_ITEMS = 'kmDialogHeaderActionItems',
-    DIALOG_HEADER_HISTORY = 'kmDialogHeaderHistory',
-    DIALOG_HEADER_SETTINGS = 'kmDialogHeaderSettings',
-    DIALOG_HEADER_OVERFLOW = 'kmDialogHeaderOverflow',
-    DIALOG_HISTORY = 'kmDialogHistory',
-    DIALOG_LOGBOOK = 'kmDialogLogbook',
-    DIALOG_ATTRIBUTES = 'kmDialogAttributes',
-    DIALOG_MEDIA_ACTIONS = 'kmDialogMediaActions',
-    DIALOG_UPDATE_ACTIONS = 'kmDialogUpdateActions',
-    DIALOG_CLIMATE_ACTIONS = 'kmDialogClimateActions',
-    DIALOG_CLIMATE_TEMPERATURE_ACTIONS = 'kmDialogClimateTemperatureActions',
-    DIALOG_CLIMATE_SETTINGS_ACTIONS = 'kmDialogClimateSettingsActions',
-    DIALOG_TIMER_ACTIONS = 'kmDialogTimerActions',
-    DIALOG_HISTORY_SHOW_MORE = 'kmDialogHistoryShowMore',
-    DIALOG_LOGBOOK_SHOW_MORE = 'kmDialogLogbookShowMore',
-    OVERFLOW_MOUSE = 'kmOverflowMouse',
-    MOUSE = 'kmMouse',
-    CONTEXT_MENU = 'kmContextMenu'
-}
-
 export enum OPTION {
     KIOSK = 'kiosk',
-    CACHE = 'cache',
-    CLEAR_CACHE = 'clear_km_cache',
-    DISABLE_KIOSK_MODE = 'disable_km',
     HIDE_SIDEBAR = 'hide_sidebar',
     HIDE_HEADER = 'hide_header',
     HIDE_OVERFLOW = 'hide_overflow',
@@ -71,10 +35,18 @@ export enum OPTION {
     BLOCK_OVERFLOW = 'block_overflow',
     BLOCK_MOUSE = 'block_mouse',
     BLOCK_CONTEXT_MENU = 'block_context_menu',
-    // Conditional configuration
+}
+
+export enum CONDITIONAL_OPTION {
     IGNORE_ENTITY_SETTINGS = 'ignore_entity_settings',
     IGNORE_MOBILE_SETTINGS = 'ignore_mobile_settings',
     IGNORE_DISABLE_KM = 'ignore_disable_km'
+}
+
+export enum SPECIAL_QUERY_PARAMS {
+    CACHE = 'cache',
+    CLEAR_CACHE = 'clear_km_cache',
+    DISABLE_KIOSK_MODE = 'disable_km',
 }
 
 const UI_PREFIX = 'ui';
@@ -152,7 +124,6 @@ export enum ELEMENT {
 }
 
 export const TRUE = 'true';
-export const FALSE = 'false';
 export const CUSTOM_MOBILE_WIDTH_DEFAULT = 812;
 export const SUSCRIBE_EVENTS_TYPE = 'subscribe_events';
 export const STATE_CHANGED_EVENT = 'state_changed';

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -10,11 +10,11 @@ import {
 	Version
 } from '@types';
 import {
-	CACHE,
 	OPTION,
+	CONDITIONAL_OPTION,
+	SPECIAL_QUERY_PARAMS,
 	ELEMENT,
 	TRUE,
-	FALSE,
 	CUSTOM_MOBILE_WIDTH_DEFAULT,
 	SUSCRIBE_EVENTS_TYPE,
 	STATE_CHANGED_EVENT,
@@ -34,7 +34,8 @@ import {
 	getMenuTranslations,
 	getPromisableElement,
 	addMenuItemsDataSelectors,
-	parseVersion
+	parseVersion,
+	resetCache
 } from '@utilities';
 import { STYLES } from '@styles';
 
@@ -43,38 +44,10 @@ import { ConInfo } from './conf-info';
 class KioskMode implements KioskModeRunner {
 	constructor() {
 		window.kioskModeEntities = {};
-		if (queryString(OPTION.CLEAR_CACHE)) {
-			setCache([
-				CACHE.HEADER,
-				CACHE.SIDEBAR,
-				CACHE.OVERFLOW,
-				CACHE.MENU_BUTTON,
-				CACHE.ACCOUNT,
-				CACHE.NOTIFICATIONS,
-				CACHE.SEARCH,
-				CACHE.ASSISTANT,
-				CACHE.REFRESH,
-				CACHE.UNUSED_ENTITIES,
-				CACHE.RELOAD_RESOURCES,
-				CACHE.EDIT_DASHBOARD,
-				CACHE.DIALOG_HEADER_ACTION_ITEMS,
-				CACHE.DIALOG_HEADER_HISTORY,
-				CACHE.DIALOG_HEADER_SETTINGS,
-				CACHE.DIALOG_HEADER_OVERFLOW,
-				CACHE.DIALOG_HISTORY,
-				CACHE.DIALOG_LOGBOOK,
-				CACHE.DIALOG_ATTRIBUTES,
-				CACHE.DIALOG_MEDIA_ACTIONS,
-				CACHE.DIALOG_UPDATE_ACTIONS,
-				CACHE.DIALOG_CLIMATE_ACTIONS,
-				CACHE.DIALOG_CLIMATE_TEMPERATURE_ACTIONS,
-				CACHE.DIALOG_CLIMATE_SETTINGS_ACTIONS,
-				CACHE.DIALOG_TIMER_ACTIONS,
-				CACHE.DIALOG_HISTORY_SHOW_MORE,
-				CACHE.DIALOG_LOGBOOK_SHOW_MORE,
-				CACHE.OVERFLOW_MOUSE,
-				CACHE.MOUSE
-			], FALSE);
+		this.options = {};
+
+		if (queryString(SPECIAL_QUERY_PARAMS.CLEAR_CACHE)) {
+			resetCache();
 		}
 
 		const selectMainElements = async () => {
@@ -153,39 +126,12 @@ class KioskMode implements KioskModeRunner {
 	private version: Version | null;
 
 	// Kiosk Mode options
-	private hideHeader: boolean;
-	private hideSidebar: boolean;
-	private hideOverflow: boolean;
-	private hideMenuButton: boolean;
-	private hideAccount: boolean;
-	private hideNotifications: boolean;
-	private hideSearch: boolean;
-	private hideAssistant: boolean;
-	private hideRefresh: boolean;
-	private hideUnusedEntities: boolean;
-	private hideReloadResources: boolean;
-	private hideEditDashboard: boolean;
-	private hideDialogHeaderActionItems: boolean;
-	private hideDialogHeaderHistory: boolean;
-	private hideDialogHeaderSettings: boolean;
-	private hideDialogHeaderOverflow: boolean;
-	private hideDialogHistory: boolean;
-	private hideDialogLogbook: boolean;
-	private hideDialogAttributes: boolean;
-	private hideDialogMediaActions: boolean;
-	private hideDialogUpdateActions: boolean;
-	private hideDialogClimateActions: boolean;
-	private hideDialogClimateTemperatureActions: boolean;
-	private hideDialogClimateSettingsActions: boolean;
-	private hideDialogTimerActions: boolean;
-	private hideDialogHistoryShowMore: boolean;
-	private hideDialogLogbookShowMore: boolean;
-	private blockOverflow: boolean;
-	private blockMouse: boolean;
-	private blockContextMenu: boolean;
-	private ignoreEntity: boolean;
-	private ignoreMobile: boolean;
-	private ignoreDisableKm: boolean;
+	private options: Partial<
+		Record<
+			OPTION | CONDITIONAL_OPTION,
+			boolean
+		>
+	>;
 
 	public run(lovelace = this.main.querySelector<Lovelace>(ELEMENT.HA_PANEL_LOVELACE)) {
 		if (!lovelace) {
@@ -278,39 +224,14 @@ class KioskMode implements KioskModeRunner {
 		if (!window.kioskModeEntities[dash]) {
 			window.kioskModeEntities[dash] = [];
 		}
-		this.hideHeader                          = false;
-		this.hideSidebar                         = false;
-		this.hideOverflow                        = false;
-		this.hideMenuButton                      = false;
-		this.hideAccount                         = false;
-		this.hideNotifications                   = false;
-		this.hideSearch                          = false;
-		this.hideAssistant                       = false;
-		this.hideRefresh                         = false;
-		this.hideUnusedEntities                  = false;
-		this.hideReloadResources                 = false;
-		this.hideEditDashboard                   = false;
-		this.hideDialogHeaderActionItems         = false;
-		this.hideDialogHeaderHistory             = false;
-		this.hideDialogHeaderSettings            = false;
-		this.hideDialogHeaderOverflow            = false;
-		this.hideDialogHistory                   = false;
-		this.hideDialogLogbook                   = false;
-		this.hideDialogAttributes                = false;
-		this.hideDialogMediaActions              = false;
-		this.hideDialogUpdateActions             = false;
-		this.hideDialogClimateActions            = false;
-		this.hideDialogClimateTemperatureActions = false;
-		this.hideDialogClimateSettingsActions    = false;
-		this.hideDialogTimerActions              = false;
-		this.hideDialogHistoryShowMore           = false;
-		this.hideDialogLogbookShowMore           = false;
-		this.blockOverflow                       = false;
-		this.blockMouse                          = false;
-		this.blockContextMenu                    = false;
-		this.ignoreEntity                        = false;
-		this.ignoreMobile                        = false;
-		this.ignoreDisableKm                     = false;
+
+		// Set all the options to false
+		Object.values(OPTION).forEach((option: OPTION) => {
+			this.options[option] = false;
+		});
+		Object.values(CONDITIONAL_OPTION).forEach((option: CONDITIONAL_OPTION) => {
+			this.options[option] = false;
+		});
 
 		this.huiRoot = await getPromisableElement(
 			(): ShadowRoot => this.lovelace?.shadowRoot?.querySelector(ELEMENT.HUI_ROOT)?.shadowRoot,
@@ -347,104 +268,17 @@ class KioskMode implements KioskModeRunner {
 			});
 
 		// Retrieve localStorage values & query string options.
-		const cachedOptionsSet = cached([
-			CACHE.HEADER,
-			CACHE.SIDEBAR,
-			CACHE.OVERFLOW,
-			CACHE.MENU_BUTTON,
-			CACHE.ACCOUNT,
-			CACHE.NOTIFICATIONS,
-			CACHE.SEARCH,
-			CACHE.ASSISTANT,
-			CACHE.REFRESH,
-			CACHE.UNUSED_ENTITIES,
-			CACHE.RELOAD_RESOURCES,
-			CACHE.EDIT_DASHBOARD,
-			CACHE.DIALOG_HEADER_ACTION_ITEMS,
-			CACHE.DIALOG_HEADER_HISTORY,
-			CACHE.DIALOG_HEADER_SETTINGS,
-			CACHE.DIALOG_HEADER_OVERFLOW,
-			CACHE.DIALOG_HISTORY,
-			CACHE.DIALOG_LOGBOOK,
-			CACHE.DIALOG_ATTRIBUTES,
-			CACHE.DIALOG_MEDIA_ACTIONS,
-			CACHE.DIALOG_UPDATE_ACTIONS,
-			CACHE.DIALOG_CLIMATE_ACTIONS,
-			CACHE.DIALOG_CLIMATE_TEMPERATURE_ACTIONS,
-			CACHE.DIALOG_CLIMATE_SETTINGS_ACTIONS,
-			CACHE.DIALOG_TIMER_ACTIONS,
-			CACHE.DIALOG_HISTORY_SHOW_MORE,
-			CACHE.DIALOG_LOGBOOK_SHOW_MORE,
-			CACHE.OVERFLOW_MOUSE,
-			CACHE.MOUSE
-		]);
-
-		const queryStringsSet = queryString([
-			OPTION.KIOSK,
-			OPTION.HIDE_HEADER,
-			OPTION.HIDE_SIDEBAR,
-			OPTION.HIDE_OVERFLOW,
-			OPTION.HIDE_MENU_BUTTON,
-			OPTION.HIDE_ACCOUNT,
-			OPTION.HIDE_NOTIFICATIONS,
-			OPTION.HIDE_SEARCH,
-			OPTION.HIDE_ASSISTANT,
-			OPTION.HIDE_REFRESH,
-			OPTION.HIDE_RELOAD_RESOURCES,
-			OPTION.HIDE_UNUSED_ENTITIES,
-			OPTION.HIDE_EDIT_DASHBOARD,
-			OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS,
-			OPTION.HIDE_DIALOG_HEADER_HISTORY,
-			OPTION.HIDE_DIALOG_HEADER_SETTINGS,
-			OPTION.HIDE_DIALOG_HEADER_OVERFLOW,
-			OPTION.HIDE_DIALOG_HISTORY,
-			OPTION.HIDE_DIALOG_LOGBOOK,
-			OPTION.HIDE_DIALOG_ATTRIBUTES,
-			OPTION.HIDE_DIALOG_MEDIA_ACTIONS,
-			OPTION.HIDE_DIALOG_UPDATE_ACTIONS,
-			OPTION.HIDE_DIALOG_CLIMATE_ACTIONS,
-			OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS,
-			OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS,
-			OPTION.HIDE_DIALOG_TIMER_ACTIONS,
-			OPTION.HIDE_DIALOG_HISTORY_SHOW_MORE,
-			OPTION.HIDE_DIALOG_LOGBOOK_SHOW_MORE,
-			OPTION.BLOCK_OVERFLOW,
-			OPTION.BLOCK_MOUSE,
-			OPTION.BLOCK_CONTEXT_MENU
-		]);
-
-		const cachedOptionsOrQueryStringsSet = cachedOptionsSet || queryStringsSet;
-		if (cachedOptionsOrQueryStringsSet) {
-			this.hideHeader                          = cached(CACHE.HEADER)                             || queryString([OPTION.KIOSK, OPTION.HIDE_HEADER]);
-			this.hideSidebar                         = cached(CACHE.SIDEBAR)                            || queryString([OPTION.KIOSK, OPTION.HIDE_SIDEBAR]);
-			this.hideOverflow                        = cached(CACHE.OVERFLOW)                           || queryString(OPTION.HIDE_OVERFLOW);
-			this.hideMenuButton                      = cached(CACHE.MENU_BUTTON)                        || queryString(OPTION.HIDE_MENU_BUTTON);
-			this.hideAccount                         = cached(CACHE.ACCOUNT)                            || queryString(OPTION.HIDE_ACCOUNT);
-			this.hideNotifications                   = cached(CACHE.NOTIFICATIONS)                      || queryString(OPTION.HIDE_NOTIFICATIONS);
-			this.hideSearch                          = cached(CACHE.SEARCH)                             || queryString(OPTION.HIDE_SEARCH);
-			this.hideAssistant                       = cached(CACHE.ASSISTANT)                          || queryString(OPTION.HIDE_ASSISTANT);
-			this.hideRefresh                         = cached(CACHE.REFRESH)                            || queryString(OPTION.HIDE_REFRESH);
-			this.hideUnusedEntities                  = cached(CACHE.UNUSED_ENTITIES)                    || queryString(OPTION.HIDE_UNUSED_ENTITIES);
-			this.hideReloadResources                 = cached(CACHE.RELOAD_RESOURCES)                   || queryString(OPTION.HIDE_RELOAD_RESOURCES);
-			this.hideEditDashboard                   = cached(CACHE.EDIT_DASHBOARD)                     || queryString(OPTION.HIDE_EDIT_DASHBOARD);
-			this.hideDialogHeaderActionItems         = cached(CACHE.DIALOG_HEADER_ACTION_ITEMS)         || queryString(OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS);
-			this.hideDialogHeaderHistory             = cached(CACHE.DIALOG_HEADER_HISTORY)              || queryString(OPTION.HIDE_DIALOG_HEADER_HISTORY);
-			this.hideDialogHeaderSettings            = cached(CACHE.DIALOG_HEADER_SETTINGS)             || queryString(OPTION.HIDE_DIALOG_HEADER_SETTINGS);
-			this.hideDialogHeaderOverflow            = cached(CACHE.DIALOG_HEADER_OVERFLOW)             || queryString(OPTION.HIDE_DIALOG_HEADER_OVERFLOW);
-			this.hideDialogHistory                   = cached(CACHE.DIALOG_HISTORY)                     || queryString(OPTION.HIDE_DIALOG_HISTORY);
-			this.hideDialogLogbook                   = cached(CACHE.DIALOG_LOGBOOK)                     || queryString(OPTION.HIDE_DIALOG_LOGBOOK);
-			this.hideDialogAttributes                = cached(CACHE.DIALOG_ATTRIBUTES)                  || queryString(OPTION.HIDE_DIALOG_ATTRIBUTES);
-			this.hideDialogMediaActions              = cached(CACHE.DIALOG_MEDIA_ACTIONS)               || queryString(OPTION.HIDE_DIALOG_MEDIA_ACTIONS);
-			this.hideDialogUpdateActions             = cached(CACHE.DIALOG_UPDATE_ACTIONS)              || queryString(OPTION.HIDE_DIALOG_UPDATE_ACTIONS);
-			this.hideDialogClimateActions            = cached(CACHE.DIALOG_CLIMATE_ACTIONS)             || queryString(OPTION.HIDE_DIALOG_CLIMATE_ACTIONS);
-			this.hideDialogClimateTemperatureActions = cached(CACHE.DIALOG_CLIMATE_TEMPERATURE_ACTIONS) || queryString(OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS);
-			this.hideDialogClimateSettingsActions    = cached(CACHE.DIALOG_CLIMATE_SETTINGS_ACTIONS)    || queryString(OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS);
-			this.hideDialogTimerActions              = cached(CACHE.DIALOG_TIMER_ACTIONS)               || queryString(OPTION.HIDE_DIALOG_TIMER_ACTIONS);
-			this.hideDialogHistoryShowMore           = cached(CACHE.DIALOG_HISTORY_SHOW_MORE)           || queryString(OPTION.HIDE_DIALOG_HISTORY_SHOW_MORE);
-			this.hideDialogLogbookShowMore           = cached(CACHE.DIALOG_LOGBOOK_SHOW_MORE)           || queryString(OPTION.HIDE_DIALOG_LOGBOOK_SHOW_MORE);
-			this.blockOverflow                       = cached(CACHE.OVERFLOW_MOUSE)                     || queryString(OPTION.BLOCK_OVERFLOW);
-			this.blockMouse                          = cached(CACHE.MOUSE)                              || queryString(OPTION.BLOCK_MOUSE);
-			this.blockContextMenu                    = cached(CACHE.CONTEXT_MENU)                       || queryString(OPTION.BLOCK_CONTEXT_MENU);
+		if (
+			cached(
+				Object.values(OPTION)
+			) ||
+			queryString(
+				Object.values(OPTION)
+			)
+		) {
+			Object.values(OPTION).forEach((option: OPTION): void => {
+				this.options[option] = cached(option) || queryString(option);
+			});
 		} else {
 			// Use config values only if config strings and cache aren't used.
 			this.setOptions(config, false);
@@ -469,7 +303,7 @@ class KioskMode implements KioskModeRunner {
 		}
 
 		// Mobile config
-		const mobileConfig = this.ignoreMobile
+		const mobileConfig = this.options[CONDITIONAL_OPTION.IGNORE_MOBILE_SETTINGS]
 			? null
 			: config.mobile_settings;
 
@@ -483,7 +317,7 @@ class KioskMode implements KioskModeRunner {
 		}
 
 		// Entity config
-		const entityConfig = this.ignoreEntity
+		const entityConfig = this.options[CONDITIONAL_OPTION.IGNORE_ENTITY_SETTINGS]
 			? null
 			: config.entity_settings;
 
@@ -501,8 +335,8 @@ class KioskMode implements KioskModeRunner {
 
 		// Do not run kiosk-mode if it is disabled
 		if (
-			queryString(OPTION.DISABLE_KIOSK_MODE) &&
-			!this.ignoreDisableKm
+			queryString(SPECIAL_QUERY_PARAMS.DISABLE_KIOSK_MODE) &&
+			!this.options[CONDITIONAL_OPTION.IGNORE_DISABLE_KM]
 		) {
 			return;
 		}
@@ -513,102 +347,123 @@ class KioskMode implements KioskModeRunner {
 	// INSERT REGULAR STYLES
 	protected insertStyles() {
 
-		// Remove toggle menu event
-		this.main?.host?.removeEventListener(TOGGLE_MENU_EVENT, this.blockEventHandler, true);
-
-		if (this.hideSidebar) {
-			this.main?.host?.addEventListener(TOGGLE_MENU_EVENT, this.blockEventHandler, true);
-		}
-
-		if (this.hideHeader) {
+		if (
+			this.options[OPTION.KIOSK] ||
+			this.options[OPTION.HIDE_HEADER]
+		) {
 			addStyle(STYLES.HEADER, this.huiRoot);
-			if (queryString(OPTION.CACHE)) setCache(CACHE.HEADER, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.HIDE_HEADER, TRUE);
 		} else {
 			removeStyle(this.huiRoot);
 		}
 
-		if (this.hideSidebar) {
+		// Remove toggle menu event
+		this.main?.host?.removeEventListener(TOGGLE_MENU_EVENT, this.blockEventHandler, true);
+
+		if (
+			this.options[OPTION.KIOSK] ||
+			this.options[OPTION.HIDE_SIDEBAR]
+		) {
+			this.main?.host?.addEventListener(TOGGLE_MENU_EVENT, this.blockEventHandler, true);
 			addStyle(STYLES.SIDEBAR, this.drawerLayout);
 			addStyle(STYLES.ASIDE, this.drawerLayout.shadowRoot);
-			if (queryString(OPTION.CACHE)) setCache(CACHE.SIDEBAR, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.HIDE_SIDEBAR, TRUE);
 		} else {
 			removeStyle(this.drawerLayout);
 			removeStyle(this.drawerLayout.shadowRoot);
 		}
 
 		if (
-			this.hideAccount ||
-			this.hideNotifications ||
-			this.hideMenuButton
+			this.options[OPTION.HIDE_ACCOUNT] ||
+			this.options[OPTION.HIDE_NOTIFICATIONS] ||
+			this.options[OPTION.HIDE_MENU_BUTTON]
 		) {
 			const styles = [
-				this.hideAccount ? STYLES.ACCOUNT : '',
-				this.hideNotifications ? STYLES.NOTIFICATIONS : '',
-				this.hideAccount && this.hideNotifications
+				this.options[OPTION.HIDE_ACCOUNT]
+					? STYLES.ACCOUNT : '',
+				this.options[OPTION.HIDE_NOTIFICATIONS]
+					? STYLES.NOTIFICATIONS : '',
+				this.options[OPTION.HIDE_ACCOUNT] && this.options[OPTION.HIDE_NOTIFICATIONS]
 					? STYLES.DIVIDER
 					: '',
-				this.hideAccount || this.hideNotifications
-					? STYLES.PEPER_LISTBOX(this.hideAccount, this.hideNotifications)
+				this.options[OPTION.HIDE_ACCOUNT] || this.options[OPTION.HIDE_NOTIFICATIONS]
+					? STYLES.PEPER_LISTBOX(
+						this.options[OPTION.HIDE_ACCOUNT],
+						this.options[OPTION.HIDE_NOTIFICATIONS]
+					)
 					: '',
-				this.hideMenuButton ? STYLES.MENU_BUTTON : '',
+				this.options[OPTION.HIDE_MENU_BUTTON]
+					? STYLES.MENU_BUTTON : '',
 			];
 			addStyle(styles.join(''), this.sideBarRoot);
-			if (this.hideAccount && queryString(OPTION.CACHE)) setCache(CACHE.ACCOUNT, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) {
+				if (this.options[OPTION.HIDE_ACCOUNT])       setCache(OPTION.HIDE_ACCOUNT, TRUE);
+				if (this.options[OPTION.HIDE_NOTIFICATIONS]) setCache(OPTION.HIDE_NOTIFICATIONS, TRUE);
+			}
 		} else {
 			removeStyle(this.sideBarRoot);
 		}
 
 		if (
-			this.hideSearch ||
-      this.hideAssistant ||
-      this.hideRefresh ||
-      this.hideUnusedEntities ||
-      this.hideReloadResources ||
-      this.hideEditDashboard ||
-      this.hideMenuButton ||
-      this.hideOverflow ||
-      this.blockOverflow ||
-      this.hideSidebar
+			this.options[OPTION.HIDE_SEARCH] ||
+			this.options[OPTION.HIDE_ASSISTANT] ||
+			this.options[OPTION.HIDE_REFRESH] ||
+			this.options[OPTION.HIDE_UNUSED_ENTITIES] ||
+			this.options[OPTION.HIDE_RELOAD_RESOURCES] ||
+			this.options[OPTION.HIDE_EDIT_DASHBOARD] ||
+			this.options[OPTION.HIDE_OVERFLOW] ||
+			this.options[OPTION.BLOCK_OVERFLOW] ||
+			this.options[OPTION.HIDE_SIDEBAR] ||
+			this.options[OPTION.HIDE_MENU_BUTTON]
 		) {
 			const styles = [
-				this.hideSearch ? STYLES.SEARCH : '',
-				this.hideAssistant ? STYLES.ASSISTANT : '',
-				this.hideRefresh ? STYLES.REFRESH : '',
-				this.hideUnusedEntities ? STYLES.UNUSED_ENTITIES : '',
-				this.hideReloadResources ? STYLES.RELOAD_RESOURCES : '',
-				this.hideEditDashboard ? STYLES.EDIT_DASHBOARD : '',
-				this.hideOverflow ? STYLES.OVERFLOW_MENU : '',
-				this.blockOverflow ? STYLES.BLOCK_OVERFLOW : '',
-				this.hideMenuButton || this.hideSidebar ? STYLES.MENU_BUTTON_BURGER : '',
+				this.options[OPTION.HIDE_SEARCH]
+					? STYLES.SEARCH : '',
+				this.options[OPTION.HIDE_ASSISTANT]
+					? STYLES.ASSISTANT : '',
+				this.options[OPTION.HIDE_REFRESH]
+					? STYLES.REFRESH : '',
+				this.options[OPTION.HIDE_UNUSED_ENTITIES]
+					? STYLES.UNUSED_ENTITIES : '',
+				this.options[OPTION.HIDE_RELOAD_RESOURCES]
+					? STYLES.RELOAD_RESOURCES : '',
+				this.options[OPTION.HIDE_EDIT_DASHBOARD]
+					? STYLES.EDIT_DASHBOARD : '',
+				this.options[OPTION.HIDE_OVERFLOW]
+					? STYLES.OVERFLOW_MENU : '',
+				this.options[OPTION.BLOCK_OVERFLOW]
+					? STYLES.BLOCK_OVERFLOW : '',
+				this.options[OPTION.HIDE_MENU_BUTTON] || this.options[OPTION.HIDE_SIDEBAR]
+					? STYLES.MENU_BUTTON_BURGER : '',
 			];
 			addStyle(styles.join(''), this.appToolbar);
-			if (queryString(OPTION.CACHE)) {
-				if (this.hideSearch) setCache(CACHE.SEARCH, TRUE);
-				if (this.hideAssistant) setCache(CACHE.ASSISTANT, TRUE);
-				if (this.hideRefresh) setCache(CACHE.REFRESH, TRUE);
-				if (this.hideUnusedEntities) setCache(CACHE.UNUSED_ENTITIES, TRUE);
-				if (this.hideReloadResources) setCache(CACHE.RELOAD_RESOURCES, TRUE);
-				if (this.hideEditDashboard) setCache(CACHE.EDIT_DASHBOARD, TRUE);
-				if (this.hideOverflow) setCache(CACHE.OVERFLOW, TRUE);
-				if (this.blockOverflow) setCache(CACHE.OVERFLOW_MOUSE, TRUE);
-				if (this.hideMenuButton) setCache(CACHE.MENU_BUTTON, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) {
+				if (this.options[OPTION.HIDE_SEARCH])           setCache(OPTION.HIDE_SEARCH, TRUE);
+				if (this.options[OPTION.HIDE_ASSISTANT])        setCache(OPTION.HIDE_ASSISTANT, TRUE);
+				if (this.options[OPTION.HIDE_REFRESH])          setCache(OPTION.HIDE_REFRESH, TRUE);
+				if (this.options[OPTION.HIDE_UNUSED_ENTITIES])  setCache(OPTION.HIDE_UNUSED_ENTITIES, TRUE);
+				if (this.options[OPTION.HIDE_RELOAD_RESOURCES]) setCache(OPTION.HIDE_RELOAD_RESOURCES, TRUE);
+				if (this.options[OPTION.HIDE_EDIT_DASHBOARD])   setCache(OPTION.HIDE_EDIT_DASHBOARD, TRUE);
+				if (this.options[OPTION.HIDE_OVERFLOW])         setCache(OPTION.HIDE_OVERFLOW, TRUE);
+				if (this.options[OPTION.BLOCK_OVERFLOW])        setCache(OPTION.BLOCK_OVERFLOW, TRUE);
+				if (this.options[OPTION.HIDE_MENU_BUTTON])      setCache(OPTION.HIDE_MENU_BUTTON, TRUE);
 			}
 		} else {
 			removeStyle(this.appToolbar);
 		}
 
-		if (this.blockMouse) {
+		if (this.options[OPTION.BLOCK_MOUSE]) {
 			addStyle(STYLES.MOUSE, document.body);
-			if (queryString(OPTION.CACHE)) setCache(CACHE.MOUSE, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.BLOCK_MOUSE, TRUE);
 		} else {
 			removeStyle(document.body);
 		}
 
 		window.removeEventListener('contextmenu', this.blockEventHandler, true);
 
-		if (this.blockContextMenu) {
+		if (this.options[OPTION.BLOCK_CONTEXT_MENU]) {
 			window.addEventListener('contextmenu', this.blockEventHandler, true);
-			if (queryString(OPTION.CACHE)) setCache(CACHE.CONTEXT_MENU, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.BLOCK_CONTEXT_MENU, TRUE);
 		}
 
 		// Resize event
@@ -635,22 +490,25 @@ class KioskMode implements KioskModeRunner {
 			});
 
 		if (
-			this.hideDialogHeaderActionItems ||
-			this.hideDialogHeaderHistory ||
-			this.hideDialogHeaderSettings ||
-			this.hideDialogHeaderOverflow
+			this.options[OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS] ||
+			this.options[OPTION.HIDE_DIALOG_HEADER_HISTORY] ||
+			this.options[OPTION.HIDE_DIALOG_HEADER_SETTINGS] ||
+			this.options[OPTION.HIDE_DIALOG_HEADER_OVERFLOW]
 		) {
 			const styles = [
-				this.hideDialogHeaderActionItems || this.hideDialogHeaderHistory ? STYLES.DIALOG_HEADER_HISTORY : '',
-				this.hideDialogHeaderActionItems || this.hideDialogHeaderSettings ? STYLES.DIALOG_HEADER_SETTINGS : '',
-				this.hideDialogHeaderActionItems || this.hideDialogHeaderOverflow ? STYLES.DIALOG_HEADER_OVERFLOW : ''
+				this.options[OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS] || this.options[OPTION.HIDE_DIALOG_HEADER_HISTORY]
+					? STYLES.DIALOG_HEADER_HISTORY : '',
+				this.options[OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS] || this.options[OPTION.HIDE_DIALOG_HEADER_SETTINGS]
+					? STYLES.DIALOG_HEADER_SETTINGS : '',
+				this.options[OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS] || this.options[OPTION.HIDE_DIALOG_HEADER_OVERFLOW]
+					? STYLES.DIALOG_HEADER_OVERFLOW : ''
 			];
 			addStyle(styles.join(''), dialog);
-			if (queryString(OPTION.CACHE)) {
-				if (this.hideDialogHeaderActionItems) setCache(CACHE.DIALOG_HEADER_ACTION_ITEMS, TRUE);
-				if (this.hideDialogHeaderHistory) setCache(CACHE.DIALOG_HEADER_HISTORY, TRUE);
-				if (this.hideDialogHeaderSettings) setCache(CACHE.DIALOG_HEADER_SETTINGS, TRUE);
-				if (this.hideDialogHeaderOverflow) setCache(CACHE.DIALOG_HEADER_OVERFLOW, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) {
+				if (this.options[OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS]) setCache(OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_HEADER_HISTORY])      setCache(OPTION.HIDE_DIALOG_HEADER_HISTORY, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_HEADER_SETTINGS])     setCache(OPTION.HIDE_DIALOG_HEADER_SETTINGS, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_HEADER_OVERFLOW])     setCache(OPTION.HIDE_DIALOG_HEADER_OVERFLOW, TRUE);
 			}
 		} else {
 			removeStyle(dialog);
@@ -673,26 +531,28 @@ class KioskMode implements KioskModeRunner {
 		);
 
 		if (
-			this.hideDialogHistory ||
-			this.hideDialogLogbook ||
-			this.hideDialogClimateActions ||
-			this.hideDialogClimateTemperatureActions ||
-			this.hideDialogClimateSettingsActions
+			this.options[OPTION.HIDE_DIALOG_HISTORY] ||
+			this.options[OPTION.HIDE_DIALOG_LOGBOOK] ||
+			this.options[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS] ||
+			this.options[OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS] ||
+			this.options[OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS]
 		) {
 			const styles = [
-				this.hideDialogHistory ? STYLES.DIALOG_HISTORY : '',
-				this.hideDialogLogbook ? STYLES.DIALOG_LOGBOOK : '',
-				this.hideDialogClimateActions && legacyClimateInfoDialog
+				this.options[OPTION.HIDE_DIALOG_HISTORY]
+					? STYLES.DIALOG_HISTORY : '',
+				this.options[OPTION.HIDE_DIALOG_LOGBOOK]
+					? STYLES.DIALOG_LOGBOOK : '',
+				this.options[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS] && legacyClimateInfoDialog
 					? STYLES.DIALOG_CLIMATE_ACTIONS
 					: ''
 			];
 			addStyle(styles.join(''), moreInfo);
-			if (queryString(OPTION.CACHE)) {
-				if (this.hideDialogHistory) setCache(CACHE.DIALOG_HISTORY, TRUE);
-				if (this.hideDialogLogbook) setCache(CACHE.DIALOG_LOGBOOK, TRUE);
-				if (this.hideDialogClimateActions) setCache(CACHE.DIALOG_CLIMATE_ACTIONS, TRUE);
-				if (this.hideDialogClimateTemperatureActions) setCache(CACHE.DIALOG_CLIMATE_TEMPERATURE_ACTIONS, TRUE);
-				if (this.hideDialogClimateSettingsActions) setCache(CACHE.DIALOG_CLIMATE_SETTINGS_ACTIONS, TRUE);
+			if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) {
+				if (this.options[OPTION.HIDE_DIALOG_HISTORY])                     setCache(OPTION.HIDE_DIALOG_HISTORY, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_LOGBOOK])                     setCache(OPTION.HIDE_DIALOG_LOGBOOK, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS])             setCache(OPTION.HIDE_DIALOG_CLIMATE_ACTIONS, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS]) setCache(OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS, TRUE);
+				if (this.options[OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS])    setCache(OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS, TRUE);
 			}
 		} else {
 			removeStyle(moreInfo);
@@ -708,8 +568,8 @@ class KioskMode implements KioskModeRunner {
 				.then((haDialogClimate: ShadowRoot) => {
 
 					if (
-						this.hideDialogClimateActions ||
-						this.hideDialogClimateSettingsActions
+						this.options[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS] ||
+						this.options[OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS]
 					) {
 						addStyle(STYLES.DIALOG_CLIMATE_CONTROL_SELECT, haDialogClimate);
 					} else {
@@ -724,8 +584,8 @@ class KioskMode implements KioskModeRunner {
 						.then((haDialogClimateTemperature: ShadowRoot) => {
 
 							if (
-								this.hideDialogClimateActions ||
-								this.hideDialogClimateTemperatureActions
+								this.options[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS] ||
+								this.options[OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS]
 							) {
 								addStyle(STYLES.DIALOG_CLIMATE_TEMPERATURE_BUTTONS, haDialogClimateTemperature);
 							} else {
@@ -740,8 +600,8 @@ class KioskMode implements KioskModeRunner {
 								.then((haDialogClimateCircularSlider: ShadowRoot) => {
 
 									if (
-										this.hideDialogClimateActions ||
-										this.hideDialogClimateTemperatureActions
+										this.options[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS] ||
+										this.options[OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS]
 									) {
 										addStyle(STYLES.DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION, haDialogClimateCircularSlider);
 									} else {
@@ -764,9 +624,9 @@ class KioskMode implements KioskModeRunner {
 			''
 		)
 			.then((dialogHistory: ShadowRoot) => {
-				if (this.hideDialogHistoryShowMore) {
+				if (this.options[OPTION.HIDE_DIALOG_HISTORY_SHOW_MORE]) {
 					addStyle(STYLES.DIALOG_SHOW_MORE, dialogHistory);
-					if (queryString(OPTION.CACHE)) setCache(CACHE.DIALOG_HISTORY_SHOW_MORE, TRUE);
+					if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.HIDE_DIALOG_HISTORY_SHOW_MORE, TRUE);
 				} else {
 					removeStyle(dialogHistory);
 				}
@@ -779,9 +639,9 @@ class KioskMode implements KioskModeRunner {
 			''
 		)
 			.then((dialogLogbook: ShadowRoot) => {
-				if (this.hideDialogLogbookShowMore) {
+				if (this.options[OPTION.HIDE_DIALOG_LOGBOOK_SHOW_MORE]) {
 					addStyle(STYLES.DIALOG_SHOW_MORE, dialogLogbook);
-					if (queryString(OPTION.CACHE)) setCache(CACHE.DIALOG_LOGBOOK_SHOW_MORE, TRUE);
+					if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.HIDE_DIALOG_LOGBOOK_SHOW_MORE, TRUE);
 				} else {
 					removeStyle(dialogLogbook);
 				}
@@ -803,25 +663,25 @@ class KioskMode implements KioskModeRunner {
 		)
 			.then((dialogChild: ShadowRoot) => {
 				if (
-					this.hideDialogAttributes ||
-					this.hideDialogTimerActions ||
-					this.hideDialogMediaActions
+					this.options[OPTION.HIDE_DIALOG_ATTRIBUTES] ||
+					this.options[OPTION.HIDE_DIALOG_TIMER_ACTIONS] ||
+					this.options[OPTION.HIDE_DIALOG_MEDIA_ACTIONS]
 				) {
 					const styles = [
-						this.hideDialogAttributes ? STYLES.DIALOG_ATTRIBUTES : '',
-						this.hideDialogTimerActions ? STYLES.DIALOG_TIMER_ACTIONS : '',
+						this.options[OPTION.HIDE_DIALOG_ATTRIBUTES] ? STYLES.DIALOG_ATTRIBUTES : '',
+						this.options[OPTION.HIDE_DIALOG_TIMER_ACTIONS] ? STYLES.DIALOG_TIMER_ACTIONS : '',
 						(
-							this.hideDialogMediaActions &&
+							this.options[OPTION.HIDE_DIALOG_MEDIA_ACTIONS] &&
 							dialogChild.host.localName === ELEMENT.HA_DIALOG_MEDIA_PLAYER
 						)
 							? STYLES.DIALOG_MEDIA_ACTIONS
 							: '',
 					];
 					addStyle(styles.join(''), dialogChild);
-					if (queryString(OPTION.CACHE)) {
-						if (this.hideDialogAttributes) setCache(CACHE.DIALOG_ATTRIBUTES, TRUE);
-						if (this.hideDialogTimerActions) setCache(CACHE.DIALOG_TIMER_ACTIONS, TRUE);
-						if (this.hideDialogMediaActions) setCache(CACHE.DIALOG_MEDIA_ACTIONS, TRUE);
+					if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) {
+						if (this.options[OPTION.HIDE_DIALOG_ATTRIBUTES])    setCache(OPTION.HIDE_DIALOG_ATTRIBUTES, TRUE);
+						if (this.options[OPTION.HIDE_DIALOG_TIMER_ACTIONS]) setCache(OPTION.HIDE_DIALOG_TIMER_ACTIONS, TRUE);
+						if (this.options[OPTION.HIDE_DIALOG_MEDIA_ACTIONS]) setCache(OPTION.HIDE_DIALOG_MEDIA_ACTIONS, TRUE);
 					}
 				} else {
 					removeStyle(dialogChild);
@@ -835,9 +695,9 @@ class KioskMode implements KioskModeRunner {
 			''
 		)
 			.then((dialogChild: ShadowRoot) => {
-				if (this.hideDialogUpdateActions) {
+				if (this.options[OPTION.HIDE_DIALOG_UPDATE_ACTIONS]) {
 					addStyle(STYLES.DIALOG_UPDATE_ACTIONS, dialogChild);
-					if (queryString(OPTION.CACHE)) setCache(CACHE.DIALOG_UPDATE_ACTIONS, TRUE);
+					if (queryString(SPECIAL_QUERY_PARAMS.CACHE)) setCache(OPTION.HIDE_DIALOG_UPDATE_ACTIONS, TRUE);
 				} else {
 					removeStyle(dialogChild);
 				}
@@ -968,46 +828,19 @@ class KioskMode implements KioskModeRunner {
 	}
 
 	protected setOptions(config: ConditionalKioskConfig, conditional: boolean) {
-		if (OPTION.HIDE_HEADER in config)                             this.hideHeader                          = config[OPTION.HIDE_HEADER];
-		if (OPTION.HIDE_SIDEBAR in config)                            this.hideSidebar                         = config[OPTION.HIDE_SIDEBAR];
-		if (OPTION.HIDE_OVERFLOW in config)                           this.hideOverflow                        = config[OPTION.HIDE_OVERFLOW];
-		if (OPTION.HIDE_MENU_BUTTON in config)                        this.hideMenuButton                      = config[OPTION.HIDE_MENU_BUTTON];
-		if (OPTION.HIDE_ACCOUNT in config)                            this.hideAccount                         = config[OPTION.HIDE_ACCOUNT];
-		if (OPTION.HIDE_NOTIFICATIONS in config)                      this.hideNotifications                   = config[OPTION.HIDE_NOTIFICATIONS];
-		if (OPTION.HIDE_SEARCH in config)                             this.hideSearch                          = config[OPTION.HIDE_SEARCH];
-		if (OPTION.HIDE_ASSISTANT in config)                          this.hideAssistant                       = config[OPTION.HIDE_ASSISTANT];
-		if (OPTION.HIDE_REFRESH in config)                            this.hideRefresh                         = config[OPTION.HIDE_REFRESH];
-		if (OPTION.HIDE_UNUSED_ENTITIES in config)                    this.hideUnusedEntities                  = config[OPTION.HIDE_UNUSED_ENTITIES];
-		if (OPTION.HIDE_RELOAD_RESOURCES in config)                   this.hideReloadResources                 = config[OPTION.HIDE_RELOAD_RESOURCES];
-		if (OPTION.HIDE_EDIT_DASHBOARD in config)                     this.hideEditDashboard                   = config[OPTION.HIDE_EDIT_DASHBOARD];
-		if (OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS in config)         this.hideDialogHeaderActionItems         = config[OPTION.HIDE_DIALOG_HEADER_ACTION_ITEMS];
-		if (OPTION.HIDE_DIALOG_HEADER_HISTORY in config)              this.hideDialogHeaderHistory             = config[OPTION.HIDE_DIALOG_HEADER_HISTORY];
-		if (OPTION.HIDE_DIALOG_HEADER_SETTINGS in config)             this.hideDialogHeaderSettings            = config[OPTION.HIDE_DIALOG_HEADER_SETTINGS];
-		if (OPTION.HIDE_DIALOG_HEADER_OVERFLOW in config)             this.hideDialogHeaderOverflow            = config[OPTION.HIDE_DIALOG_HEADER_OVERFLOW];
-		if (OPTION.HIDE_DIALOG_HISTORY in config)                     this.hideDialogHistory                   = config[OPTION.HIDE_DIALOG_HISTORY];
-		if (OPTION.HIDE_DIALOG_LOGBOOK in config)                     this.hideDialogLogbook                   = config[OPTION.HIDE_DIALOG_LOGBOOK];
-		if (OPTION.HIDE_DIALOG_ATTRIBUTES in config)                  this.hideDialogAttributes                = config[OPTION.HIDE_DIALOG_ATTRIBUTES];
-		if (OPTION.HIDE_DIALOG_MEDIA_ACTIONS in config)               this.hideDialogMediaActions              = config[OPTION.HIDE_DIALOG_MEDIA_ACTIONS];
-		if (OPTION.HIDE_DIALOG_UPDATE_ACTIONS in config)              this.hideDialogUpdateActions             = config[OPTION.HIDE_DIALOG_UPDATE_ACTIONS];
-		if (OPTION.HIDE_DIALOG_CLIMATE_ACTIONS in config)             this.hideDialogClimateActions            = config[OPTION.HIDE_DIALOG_CLIMATE_ACTIONS];
-		if (OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS in config) this.hideDialogClimateTemperatureActions = config[OPTION.HIDE_DIALOG_CLIMATE_TEMPERATURE_ACTIONS];
-		if (OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS in config)    this.hideDialogClimateSettingsActions    = config[OPTION.HIDE_DIALOG_CLIMATE_SETTINGS_ACTIONS];
-		if (OPTION.HIDE_DIALOG_TIMER_ACTIONS in config)               this.hideDialogTimerActions              = config[OPTION.HIDE_DIALOG_TIMER_ACTIONS];
-		if (OPTION.HIDE_DIALOG_HISTORY_SHOW_MORE in config)           this.hideDialogHistoryShowMore           = config[OPTION.HIDE_DIALOG_HISTORY_SHOW_MORE];
-		if (OPTION.HIDE_DIALOG_LOGBOOK_SHOW_MORE in config)           this.hideDialogLogbookShowMore           = config[OPTION.HIDE_DIALOG_LOGBOOK_SHOW_MORE];
-		if (OPTION.BLOCK_OVERFLOW in config)                          this.blockOverflow                       = config[OPTION.BLOCK_OVERFLOW];
-		if (OPTION.BLOCK_MOUSE in config)                             this.blockMouse                          = config[OPTION.BLOCK_MOUSE];
-		if (OPTION.BLOCK_CONTEXT_MENU in config)                      this.blockContextMenu                    = config[OPTION.BLOCK_CONTEXT_MENU];
-		if (OPTION.KIOSK in config)                                   this.hideHeader                          = this.hideSidebar = config[OPTION.KIOSK];
-
+		Object.values(OPTION).forEach((option: OPTION): void => {
+			if (option in config) {
+				this.options[option] = config[option];
+			}
+		});
 		if (conditional) {
-			if (OPTION.IGNORE_ENTITY_SETTINGS in config)        this.ignoreEntity              = config[OPTION.IGNORE_ENTITY_SETTINGS];
-			if (OPTION.IGNORE_MOBILE_SETTINGS in config)        this.ignoreMobile              = config[OPTION.IGNORE_MOBILE_SETTINGS];
-			if (OPTION.IGNORE_DISABLE_KM in config)             this.ignoreDisableKm           = config[OPTION.IGNORE_DISABLE_KM];
+			Object.values(CONDITIONAL_OPTION).forEach((option: CONDITIONAL_OPTION): void => {
+				if (option in config) {
+					this.options[option] = config[option];
+				}
+			});
 		}
-
 	}
-
 }
 
 // Console tag

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { OPTION, CONDITIONAL_OPTION } from '@constants';
+
 export interface KioskModeRunner {
     run: (lovelace: HTMLElement) => Promise<void>;
     runDialogs: (moreInfoDialog: Element) => Promise<void>;
@@ -24,38 +26,21 @@ export interface EntitySetting extends KioskConfig {
 
 export type EntitySettings = EntitySetting[];
 
-export interface KioskConfig {
-    kiosk?: boolean;
-    hide_header?: boolean;
-    hide_sidebar?: boolean;
-    hide_overflow?: boolean;
-    hide_menubutton?: boolean;
-    hide_account?: boolean;
-    hide_notifications?: boolean;
-    hide_search?: boolean;
-    hide_assistant?: boolean;
-    hide_refresh?: boolean;
-    hide_unused_entities?: boolean;
-    hide_reload_resources?: boolean;
-    hide_edit_dashboard?: boolean;
-    hide_dialog_header_action_items?: boolean;
-    hide_dialog_header_history?: boolean;
-    hide_dialog_header_settings?: boolean;
-    hide_dialog_header_overflow?: boolean;
-    hide_dialog_history?: boolean;
-    hide_dialog_logbook?: boolean;
-    hide_dialog_attributes?: boolean;
-    hide_dialog_media_actions?: boolean;
-    hide_dialog_update_actions?: boolean;
-    hide_dialog_climate_actions?: boolean;
-    hide_dialog_climate_temperature_actions?: boolean;
-    hide_dialog_climate_settings_actions?: boolean;
-    hide_dialog_timer_actions?: boolean;
-    hide_dialog_history_show_more?: boolean;
-    hide_dialog_logbook_show_more?: boolean;
-    block_overflow?: boolean;
-    block_mouse?: boolean;
-    block_context_menu?: boolean;
+type BaseKioskConfig = Partial<
+    Record<
+        OPTION,
+        boolean
+    >
+>;
+
+type BaseConditionalKioskConfig = Partial<
+    Record<
+        CONDITIONAL_OPTION,
+        boolean
+    >
+>;
+
+export interface KioskConfig extends BaseKioskConfig {
     admin_settings?: ConditionalKioskConfig;
     non_admin_settings?: ConditionalKioskConfig;
     user_settings?: UserSetting[];
@@ -63,11 +48,7 @@ export interface KioskConfig {
     entity_settings?: EntitySettings;
 }
 
-export interface ConditionalKioskConfig extends KioskConfig {
-    ignore_entity_settings?: boolean;
-    ignore_mobile_settings?: boolean;
-    ignore_disable_km?: boolean;
-}
+export type ConditionalKioskConfig = KioskConfig & BaseConditionalKioskConfig;
 
 export interface EntityState {
     state: string;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -10,7 +10,8 @@ import {
 	MAX_ATTEMPTS,
 	RETRY_DELAY,
 	NAMESPACE,
-	ELEMENT
+	ELEMENT,
+	OPTION
 } from '@constants';
 
 // Convert to array
@@ -50,19 +51,46 @@ export const removeStyle = (elements: StyleElement): void => {
 	});
 };
 
+// Get cache key
+export const getCacheKey = (option: string): string => {
+	const optionCamelCase = option.replace(/(?:^|_)([a-z])/g, (__match: string, letter): string => {
+		return letter.toUpperCase();
+	});
+	return `km${optionCamelCase}`;
+};
+
 // Return true if keyword is found in query strings.
 export const queryString = (keywords: string | string[]): boolean => {
-	return toArray(keywords).some((x) => window.location.search.includes(x));
+	const params = new URLSearchParams(window.location.search);
+	return toArray(keywords).some((x) => params.has(x));
 };
 
 // Set localStorage item.
-export const setCache = (k: string | string[], v: string): void => {
-	toArray(k).forEach((x) => window.localStorage.setItem(x, v));
+export const setCache = (options: OPTION | OPTION[], value: string): void => {
+	toArray(options)
+		.forEach(
+			(option) => window.localStorage.setItem(
+				getCacheKey(option),
+				value
+			)
+		);
 };
 
 // Retrieve localStorage item as bool.
-export const cached = (key: string | string[]): boolean => {
-	return toArray(key).some((x) => window.localStorage.getItem(x) === TRUE);
+export const cached = (options: OPTION | OPTION[]): boolean => {
+	return toArray(options)
+		.some((option) => {
+			return window.localStorage.getItem(getCacheKey(option)) === TRUE;
+		});
+};
+
+// Reset all cache items to false
+export const resetCache = () => {
+	Object.values(OPTION).forEach((option: OPTION): void => {
+		window.localStorage.removeItem(
+			getCacheKey(option)
+		);
+	});
 };
 
 // Convert a CSS in JS to string


### PR DESCRIPTION
In [this pull request](https://github.com/NemesisRE/kiosk-mode/pull/131) a bug was introduced. The new `block_context_menu` [was not added to the cache reset](https://github.com/NemesisRE/kiosk-mode/pull/131/files#diff-61c1ab70aec66e7593097fd45599cfd2e468d5b722305c9b7ed6d01e4a161a35L76), so if the cache is set with this option enabled it cannot be undone unless one manually cleans the `localStorage`. It is logic that errors like this happen because it is very difficult at the moment to add a new option to the project due to the number of places in which this should be reflected:

1. [Add the option to the types](https://github.com/NemesisRE/kiosk-mode/blob/570c7502e4bc466c0a7888b61c0d5c370ce83608/src/types/index.ts#L28-L63)
2. [Add the option to the option enum](https://github.com/NemesisRE/kiosk-mode/blob/master/src/constants/index.ts#L39-L78)
3. [Add the relative option value to the cache enum](https://github.com/NemesisRE/kiosk-mode/blob/master/src/constants/index.ts#L6-L37)
4. [Add the proper cache reset](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L48-L76)
5. [Add the option to the private properties of the class](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L156-L188)
6. [Set the value of the private property to false](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L281-L313)
7. [Check if the new option is cached](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L350-L380)
8. [Check if the new option is in the query parameters](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L382-L413)
9. [Set the private property to the value in the cache or the string parameter](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L418-L447)
10. [Add the new option to the setOptions method](https://github.com/NemesisRE/kiosk-mode/blob/master/src/kiosk-mode.ts#L971-L1007)

This is very hard to maintain and scalate and it makes it difficult for others to contribute to the project without making errors. The purpose of this pull request is to solve this doing the next changes:

1. The only place to add a new option will be the `option` enum
2. The types are generated from the `option` enum, so no need to manually add the options there
3. The cache parameters are generated dynamically from the `option` enum, so no need to add it there either
4. To check for the cache or url parameters the values of the `option` enum are used
5. The private properties of the class have been removed and they are set inside a private object that only admits as keys the `option` enum values
6. All the methods to set the options are now loops of the `option` enum to set the proper values if they are contained in the config

Also, as part of this pull request the next changes have been applied:

1. The bug related to the context menu cache has been fixed (automatically because now the cache keys are taken from the `option` enum)
2. When one cleans the cache, instead of setting the values of the keys to `false` , the keys are removed from the `localStore` (perform a real clean)
3. Avoid checking the cache parameter in the URL using a `location.search.includes` because this will make that the options are cached if there is something in the URL search-parameters that contains the substring `cache`, like for example `cachepot`. This was provoking that the options were cached if the URL contained `clear_km_cache`.

### Note

> Users that use the `cache` options would require to cache the options again adding `?cache` to the URL because the cache keys will change with this pull request. Previously, cache keys had a totally different name, for example, for the option `hide_header` the cache key was `kmHeader`, at the moment it is `kmHideHeader`.