### PR TITLE
Remove a line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,6 @@ This works for all query strings except for the utility strings listed below.
 * Run `yarn`
 * Run `yarn demo` (`yarn demo:win` on Windows environments)
 * Open http://localhost:8123/
-* Create an account and complete the onboard
 
 ## Kiosk-mode complements
 


### PR DESCRIPTION
It is not needed anymore to onboard into Home Assistant if the demo is open, with the usage of trusted networks and a creation of a default account, the session is opened automatically. This pull request removes a line in the README that mentioned that one needed to create an account and onboard into HA.