### PR TITLE
Cache Docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,10 @@ jobs:
           path: |
             ~/.cache
           key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.6
+        with:
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('package.json') }}
       - name: Install deps
         run: yarn install --frozen-lockfile
       - name: E2E tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,10 @@ jobs:
           path: |
             ~/.cache
           key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.6
+        with:
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('package.json') }}
       - name: Install
         run: yarn install --frozen-lockfile
       - name: E2E tests


### PR DESCRIPTION
At the moment we use two Docker images during the workflow pipelines, `home-assistant` and `mcr.microsoft.com/playwright`. These images need to be downloaded each time the pipelines run because they are not present in the Github runners.

This pull request adds the [ScribeMD/docker-cache](https://github.com/ScribeMD/docker-cache) action to store these images in cache and reuse them from the cache instead download them on each pipeline run.

### Download home-assistant Docker image

![image](https://github.com/NemesisRE/kiosk-mode/assets/3728220/c34b4365-8fcf-45bd-9ba7-51100a926237)

### Download mcr.microsoft.com/playwright Docker image

![image](https://github.com/NemesisRE/kiosk-mode/assets/3728220/242599eb-487c-411d-8291-7581435f7472)

### Caching Docker images

<img width="997" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/894c3f96-f9f3-4342-9a92-db91b1d49d6c">

### Loading cached Docker images

<img width="553" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/18f1b5c5-097a-4c17-bac4-37d512af19aa">

### Docker doesn‘t need to download the images again

<img width="1311" alt="image" src="https://github.com/NemesisRE/kiosk-mode/assets/3728220/3805633f-215f-4586-9b83-b5f08cc55d72">

