### PR TITLE
Enable dependabot dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: "[Dependencies]"
+    groups:
+      dependencies-prod:
+        dependency-type: "production"
+      dependencies-dev:
+        dependency-type: "development"
+    labels:
+      - dependencies
+    versioning-strategy: increase


### PR DESCRIPTION
The library has started to depend on many package, 1 production dependency and 15 development dependencies. It is becoming harder to keep them up to date so it is time to enable `dependabot` in the repository to manaje this automatically.

As there is only one production dependency and most of the development dependencies are used in the pipelines to build the bundle and test the code, the dependencies have been grouped in two to reduce the number of pull request. At the same time, the bot has been configured to run only once per week on Sundays, to avoid it creating too much noise.