### PR TITLE
Fix nightly beta tests

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -29,4 +29,7 @@ jobs:
       - name: Install
         run: yarn install --frozen-lockfile
       - name: E2E Tests
-        run: TAG=beta yarn test:ci
+        run: |
+          touch .env
+          echo HA_TOKEN=${{ secrets.CYPRESS_HA_TOKEN }} >> .env
+          TAG=beta yarn test:ci


### PR DESCRIPTION
[The Nightly Beta Tests are failing](https://github.com/NemesisRE/kiosk-mode/actions/workflows/ha-beta-tests.yaml). To run the e2e tests a Home Assistant token is needed and this step missed in the job.

Closes: #191