### PR TITLE
If there is no hass object, avoid executing the entityWatchCallback method

### DIFF
--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -80,23 +80,16 @@ class KioskMode implements KioskModeRunner {
 			this.appToolbar = await HEADER.selector.query(ELEMENT.TOOLBAR).element;
 			this.sideBarRoot = await HA_SIDEBAR.selector.$.element;
 
-			if (this.huiRoot) {
+			this.user = await getPromisableElement(
+				(): User => this.ha?.hass?.user,
+				(user: User) => !!user,
+				`${ELEMENT.HOME_ASSISTANT} > hass > user`
+			);
 
-				this.user = await getPromisableElement(
-					(): User => this.ha?.hass?.user,
-					(user: User) => !!user,
-					`${ELEMENT.HOME_ASSISTANT} > hass > user`
-				);
+			this.version = parseVersion(this.ha.hass?.config?.version);
 
-				this.version = parseVersion(this.ha.hass?.config?.version);
-
-				// Start kiosk-mode
-				this.run();
-
-				// Start entity watch
-				this.entityWatch();
-
-			}
+			// Start kiosk-mode
+			this.run();
 
 		});
 
@@ -111,6 +104,7 @@ class KioskMode implements KioskModeRunner {
 		});
 
 		selector.listen();
+		this.entityWatch();
 		this.resizeWindowBinded = this.resizeWindow.bind(this);
 
 	}

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -80,16 +80,23 @@ class KioskMode implements KioskModeRunner {
 			this.appToolbar = await HEADER.selector.query(ELEMENT.TOOLBAR).element;
 			this.sideBarRoot = await HA_SIDEBAR.selector.$.element;
 
-			this.user = await getPromisableElement(
-				(): User => this.ha?.hass?.user,
-				(user: User) => !!user,
-				`${ELEMENT.HOME_ASSISTANT} > hass > user`
-			);
+			if (this.huiRoot) {
 
-			this.version = parseVersion(this.ha.hass?.config?.version);
+				this.user = await getPromisableElement(
+					(): User => this.ha?.hass?.user,
+					(user: User) => !!user,
+					`${ELEMENT.HOME_ASSISTANT} > hass > user`
+				);
 
-			// Start kiosk-mode
-			this.run();
+				this.version = parseVersion(this.ha.hass?.config?.version);
+
+				// Start kiosk-mode
+				this.run();
+
+				// Start entity watch
+				this.entityWatch();
+
+			}
 
 		});
 
@@ -104,7 +111,6 @@ class KioskMode implements KioskModeRunner {
 		});
 
 		selector.listen();
-		this.entityWatch();
 		this.resizeWindowBinded = this.resizeWindow.bind(this);
 
 	}
@@ -679,7 +685,7 @@ class KioskMode implements KioskModeRunner {
 	}
 
 	protected async entityWatchCallback(event: SuscriberEvent) {
-		const entities = window.kioskModeEntities[this.ha.hass.panelUrl] || [];
+		const entities = window.kioskModeEntities[this.ha?.hass?.panelUrl] || [];
 		if (
 			entities.length &&
 			event.event_type === STATE_CHANGED_EVENT &&


### PR DESCRIPTION
This pull request avoids executing the `entityWatchCallback` method if the code is executed in a non-lovelace dashboard. By default, `kiosk-mode` only works in lovelace dashboards, but we have recently discovered that if is used in a device with [browser-mod](https://github.com/thomasloven/hass-browser_mod) installed, the code is executed in non-lovelace dashboards and therefore it throws errors trying to find non-existent elements.

Closes: #197 