### PR TITLE
Create a script to setup Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "reset:ha": "git add .hass/config/.HA_VERSION && git checkout .hass/config",
     "demo": "yarn build && yarn start:ha",
     "demo:win": "yarn build && yarn start:ha:win",
-    "prepare": "yarn build",
+    "husky:setup": "husky",
+    "prepare": "yarn build && yarn husky:setup",
     "prepublishOnly": "yarn test:all",
     "version": "git add .",
     "postversion": "git push && git push --tags"

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,15 +865,10 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001518:
-  version "1.0.30001525"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz"
-  integrity sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==
-
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001570"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz#b4e5c1fa786f733ab78fc70f592df6b3f23244ca"
-  integrity sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==
+caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001518, caniuse-lite@^1.0.30001565:
+  version "1.0.30001610"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz"
+  integrity sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
Husky needs to be setup at least once in a repo to start to work. This pull request creates a Husky script that will run on the prepare script to ensure that this command is run at least once when the dependencies are installed.

>Note: as part of this pull request `caniuse-lite` has been updated.