### PR TITLE
fix: ensure CSS variable are usable in calc

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -49,7 +49,7 @@ export const STYLES = {
 	}),
 	SIDEBAR: getCSSRulesString({
 		':host': {
-			'--mdc-drawer-width': '0 !important'
+			'--mdc-drawer-width': '0px !important'
 		},
 		'partial-panel-resolver': {
 			'--mdc-top-app-bar-width': '100% !important'


### PR DESCRIPTION
Hello! I'm contributing to a HA plugin that  uses the `--mdc-drawer-width` variable to make some calculation.

However, when using in dual with kisok-mode, it does not display because the `calc` function does not recognize unit-less values.

It is not really recommended to use unit less values in CSS variables -although it's perfectly fine outside the CSS variables scope- because it blocks the usage of `calc`.

WDYT?