### PR TITLE
fix: ensure CSS variable are usable in calc

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -49,7 +49,7 @@ export const STYLES = {
 	}),
 	SIDEBAR: getCSSRulesString({
 		':host': {
-			'--mdc-drawer-width': '0 !important'
+			'--mdc-drawer-width': '0px !important'
 		},
 		'partial-panel-resolver': {
 			'--mdc-top-app-bar-width': '100% !important'


### PR DESCRIPTION
This PR is just a clone of [this one](https://github.com/NemesisRE/kiosk-mode/pull/232). Tests are failing there because the PR doesn't have access to the repository secrets.