### PR TITLE
Fix hide_sidebar option in Companion App

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -132,6 +132,7 @@ export const CUSTOM_MOBILE_WIDTH_DEFAULT = 812;
 export const SUSCRIBE_EVENTS_TYPE = 'subscribe_events';
 export const STATE_CHANGED_EVENT = 'state_changed';
 export const TOGGLE_MENU_EVENT = 'hass-toggle-menu';
+export const MC_DRAWER_CLOSED_EVENT = 'MDCDrawer:closed';
 export const MAX_ATTEMPTS = 500;
 export const RETRY_DELAY = 50;
 export const WINDOW_RESIZE_DELAY = 250;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,11 @@ export class Lovelace extends HTMLElement {
     };
 }
 
+export class HaSidebar extends HTMLElement {
+	type: 'modal' | '';
+	appContent: HTMLElement;
+}
+
 export type SuscriberEvent = {
     event_type: string;
     data: {


### PR DESCRIPTION
When one opens and closes the sidebar, there is a logic behind to manage [the Navigation Drawer](https://m2.material.io/components/navigation-drawer/web) and [its focus trap](https://github.com/home-assistant/frontend/blob/3478bd309b3f56775c341ee14b788fae02f2552f/src/components/ha-drawer.ts#L17-L31).

If one hides the sidebar and applies all the styling override that `kiosk-modes` applies, the logic to remove all [the inert blockers](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert) from the screen and to set all the elements in a closed state is never executed. This is not a problem for those that set `hide_sidebar` globally in all the dashboards, but it is a problem if someone wants a dashboard without sidebar and navigates to it from a dashboard with it enabled, because in that moment the logic to close the sidebar is executed and as the sidebar never closes this provokes that it is impossible to interact with the interface.

In this pull request a small fix has been introduced. Before hiding the sidebar, we are checking if the `type` of the `mc-drawer` element is `modal` (it occurs in mobile) and if its `appContent` has the `inert` property set in `true` (in those cases it is impossible to interact with the screen). If that is the case, then we wait for the [MDCDrawer:closed event](https://m2.material.io/components/navigation-drawer/web#usage-within-web-frameworks) of the Navigation Drawer, and only after it is fired, we apply the styles to hide the sidebar. In the rest of the cases we hide the sidebar directly without waiting for this event.

Closes #275 