### PR TITLE
Hide menu when hide_menubutton is activated and the sidebar is collapsed

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,5 +25,11 @@ module.exports = [
 			'@typescript-eslint/no-duplicate-enum-values': 'off',
 			'@typescript-eslint/no-var-requires': 'off'
 		}
+	},
+	{
+		files: ['**/*.js'],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off'
+		}
 	}
 ];

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/sinon": "^17.0.3",
     "dotenv-cli": "^7.4.2",
     "eslint": "^9.12.0",
+    "globals": "^15.11.0",
     "nyc": "^17.1.0",
     "playwright-test-coverage": "^1.2.12",
     "rollup": "^4.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       eslint:
         specifier: ^9.12.0
         version: 9.12.0
+      globals:
+        specifier: ^15.11.0
+        version: 15.11.0
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -908,6 +911,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.11.0:
+    resolution: {integrity: sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==}
     engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
@@ -2476,6 +2483,8 @@ snapshots:
   globals@11.12.0: {}
 
   globals@14.0.0: {}
+
+  globals@15.11.0: {}
 
   graceful-fs@4.2.11: {}
 

--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -316,10 +316,13 @@ class KioskMode implements KioskModeRunner {
 				this.options[OPTION.HIDE_ACCOUNT] && this.options[OPTION.HIDE_NOTIFICATIONS]
 					? STYLES.DIVIDER
 					: '',
-				this.options[OPTION.HIDE_ACCOUNT] || this.options[OPTION.HIDE_NOTIFICATIONS]
+				this.options[OPTION.HIDE_MENU_BUTTON] ||
+				this.options[OPTION.HIDE_NOTIFICATIONS] ||
+				this.options[OPTION.HIDE_ACCOUNT]
 					? STYLES.PAPER_LISTBOX(
+						this.options[OPTION.HIDE_MENU_BUTTON],
+						this.options[OPTION.HIDE_NOTIFICATIONS],
 						this.options[OPTION.HIDE_ACCOUNT],
-						this.options[OPTION.HIDE_NOTIFICATIONS]
 					)
 					: '',
 				this.options[OPTION.HIDE_MENU_BUTTON]

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -17,22 +17,47 @@ export const STYLES = {
 	ACCOUNT: getDisplayNoneRulesString('.profile'),
 	NOTIFICATIONS: getDisplayNoneRulesString('.notifications-container'),
 	DIVIDER: getDisplayNoneRulesString('.divider'),
-	PAPER_LISTBOX: (hideAccount: boolean, hideNotifications: boolean) => {
-		let size = 132;
+	PAPER_LISTBOX: (
+		hideMenuButton: boolean,
+		hideNotifications: boolean,
+		hideAccount: boolean		
+	) => {
+		const menuButtonHeight = 56;
+		const notificationsHeight = 48;
+		const accountHeight = 50;
+		let sizeMinimized = 132;
+		let sizeExpanded = 132;
 		if (hideAccount && hideNotifications) {
-			size = 0;
+			sizeMinimized = 0;
+			sizeExpanded = 0;
 		} else if (hideAccount) {
-			size -= 50;
+			sizeMinimized -= accountHeight;
+			sizeExpanded -= accountHeight;
 		} else if (hideNotifications) {
-			size -= 48;
+			sizeMinimized -= notificationsHeight;
+			sizeExpanded -= notificationsHeight;
+		}
+		if (hideMenuButton) {
+			sizeMinimized -= menuButtonHeight;
 		}
 		return getCSSRulesString({
-			'paper-listbox': {
-				height: `calc(100% - var(--header-height) - ${size}px - env(safe-area-inset-bottom)) !important`
+			':host(:not([expanded])) paper-listbox': {
+				height: `calc(100% - var(--header-height) - ${sizeMinimized}px - env(safe-area-inset-bottom)) !important`
+			},
+			':host([expanded]) paper-listbox': {
+				height: `calc(100% - var(--header-height) - ${sizeExpanded}px - env(safe-area-inset-bottom)) !important`
 			}
 		});
 	},
-	MENU_BUTTON: getDisplayNoneRulesString('.menu ha-icon-button'),
+	//,
+	MENU_BUTTON: `
+		:host(:not([expanded])) {
+			${ getDisplayNoneRulesString('.menu') }
+		}
+		:host([expanded]) {
+			${ getDisplayNoneRulesString('.menu ha-icon-button') }
+		}
+	`,
 	MENU_BUTTON_BURGER: getDisplayNoneRulesString('ha-menu-button'),
 	MOUSE: getCSSRulesString({
 		'body::after': {

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -20,7 +20,7 @@ export const STYLES = {
 	PAPER_LISTBOX: (
 		hideMenuButton: boolean,
 		hideNotifications: boolean,
-		hideAccount: boolean		
+		hideAccount: boolean
 	) => {
 		const menuButtonHeight = 56;
 		const notificationsHeight = 48;


### PR DESCRIPTION
This pull request hides completely the `.menu` element when the `hide_menubutton` is activated and the sidebar is collapsed. This is to avoid an empty space that remains when the menu button is removed.

### `hide_menubutton` is true and the sidebar is collapsed:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/a0c16e17-23bf-48f5-8a4f-a41111ec5ed0) | ![image](https://github.com/user-attachments/assets/ebf88d37-2bbe-45a5-a6ec-f20dc9137e40) |

Closes: #284 