### PR TITLE
Fix hide_menubutton in Safari

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -49,14 +49,9 @@ export const STYLES = {
 			}
 		});
 	},
-	//,
 	MENU_BUTTON: `
-		:host(:not([expanded])) {
-			${ getDisplayNoneRulesString('.menu') }
-		}
-		:host([expanded]) {
-			${ getDisplayNoneRulesString('.menu ha-icon-button') }
-		}
+		${ getDisplayNoneRulesString(':host(:not([expanded])) .menu') }
+		${ getDisplayNoneRulesString(':host([expanded]) .menu ha-icon-button') }
 	`,
 	MENU_BUTTON_BURGER: getDisplayNoneRulesString('ha-menu-button'),
 	MOUSE: getCSSRulesString({


### PR DESCRIPTION
I have just learned that Safari browsers [are terribly bugous using the :host() function together with nested styles](https://github.com/elchininet/custom-sidebar/pull/176). [A recent new feature](https://github.com/NemesisRE/kiosk-mode/pull/285) was released using the `host()` function and nested styles. I have tested this new feature in Safari and indeed, it fails in this browser.

In this pull request the nested CSS rules are removed and regular CSS rules are used. This fixes the Safari bug.

