### PR TITLE
Change instructions to add the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ frontend:
 
 ## Simple config example
 
-YAML mode users need to add the configuration manually to the lovelace dashboard file in which they want to enable `kiosk-mode`. Non-YAML users (Storage Mode) need to add the configuration to each lovelace panel going to `Edit Dashboard` option (located in the overflow menu that appears when one clicks on the top-right three-dots button). Once in `Edit Dashboard` mode, click again on the top-right three-dots button and select `Raw configuration editor`.
+YAML mode users need to add the configuration manually to the lovelace dashboard file in which they want to enable `kiosk-mode`. Non-YAML users (Storage Mode) need to add the configuration to each lovelace panel going to `Edit dashboard` option (pencil icon on the top-right of the screen). Once in `Edit Dashboard` mode, click on the top-right three-dots button and select `Raw configuration editor`.
 
 ```
 kiosk_mode:


### PR DESCRIPTION
In the latests versions of Home Assistant, the `Edit dashboard` entry-point is not located in the overflow menu anymore because in storage mode [this menu doesn't exist](https://github.com/NemesisRE/kiosk-mode/issues/206).

This pull request changes the instructions about how to add the configuration in the README using the current Home Assistant UI.