### PR TITLE
Remove local styles management and start using Home Assistant Styles Manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "home-assistant-query-selector": "^4.2.0"
+    "home-assistant-query-selector": "4.2.0",
+    "home-assistant-styles-manager": "3.0.0"
   },
   "devDependencies": {
     "@playwright/test": "1.48.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       home-assistant-query-selector:
-        specifier: ^4.2.0
+        specifier: 4.2.0
         version: 4.2.0
+      home-assistant-styles-manager:
+        specifier: 3.0.0
+        version: 3.0.0
     devDependencies:
       '@playwright/test':
         specifier: 1.48.2
@@ -964,6 +967,9 @@ packages:
 
   home-assistant-query-selector@4.2.0:
     resolution: {integrity: sha512-8VwrqTunsE3sgakCirBdQgrZTvWgT1SIaVthpgVCeaA/8dUK0qQfn3JFUcwaa8xm0NUa8yDgjRkxKe9lGHA65Q==}
+
+  home-assistant-styles-manager@3.0.0:
+    resolution: {integrity: sha512-h3TZeaRGxcxNNFGWr1VPhiecTqgxRiC053wH1/+3A7CSwD/dQ3EfIb+d5G+udRc5hFxijUk9UQnvT2yTp2UMtA==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2537,6 +2543,8 @@ snapshots:
   home-assistant-query-selector@4.2.0:
     dependencies:
       shadow-dom-selector: 4.1.2
+
+  home-assistant-styles-manager@3.0.0: {}
 
   html-escaper@2.0.2: {}
 

--- a/src/conf-info.ts
+++ b/src/conf-info.ts
@@ -1,4 +1,4 @@
-import { getCSSString } from '@utilities';
+import { getCSSString } from 'home-assistant-styles-manager';
 import { version } from '../package.json';
 
 interface Line {

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,22 +1,17 @@
 import { MENU, ELEMENT } from '@constants';
-import {
-	getCSSRulesString,
-	getDisplayNoneRulesString
-} from '@utilities';
+import { getDisplayNoneRules } from '@utilities';
 
 export const STYLES = {
-	HEADER: getCSSRulesString({
+	HEADER: {
 		'#view': {
-			'min-height': '100vh !important',
-			'--header-height': '0px'
+			minHeight: '100vh !important',
+			HeaderHeight: '0px'
 		},
-		'.header': {
-			'display': 'none'
-		}
-	}),
-	ACCOUNT: getDisplayNoneRulesString('.profile'),
-	NOTIFICATIONS: getDisplayNoneRulesString('.notifications-container'),
-	DIVIDER: getDisplayNoneRulesString('.divider'),
+		'.header': false
+	},
+	ACCOUNT: getDisplayNoneRules('.profile'),
+	NOTIFICATIONS: getDisplayNoneRules('.notifications-container'),
+	DIVIDER: getDisplayNoneRules('.divider'),
 	PAPER_LISTBOX: (
 		hideMenuButton: boolean,
 		hideNotifications: boolean,
@@ -40,127 +35,119 @@ export const STYLES = {
 		if (hideMenuButton) {
 			sizeMinimized -= menuButtonHeight;
 		}
-		return getCSSRulesString({
+		return {
 			':host(:not([expanded])) paper-listbox': {
 				height: `calc(100% - var(--header-height) - ${sizeMinimized}px - env(safe-area-inset-bottom)) !important`
 			},
 			':host([expanded]) paper-listbox': {
 				height: `calc(100% - var(--header-height) - ${sizeExpanded}px - env(safe-area-inset-bottom)) !important`
 			}
-		});
+		};
 	},
-	MENU_BUTTON: `
-		${ getDisplayNoneRulesString(':host(:not([expanded])) .menu') }
-		${ getDisplayNoneRulesString(':host([expanded]) .menu ha-icon-button') }
-	`,
-	MENU_BUTTON_BURGER: getDisplayNoneRulesString('ha-menu-button'),
-	MOUSE: getCSSRulesString({
+	MENU_BUTTON: getDisplayNoneRules(
+		':host(:not([expanded])) .menu',
+		':host([expanded]) .menu ha-icon-button'
+	),
+	MENU_BUTTON_BURGER: getDisplayNoneRules('ha-menu-button'),
+	MOUSE: {
 		'body::after': {
-			'bottom': '0',
-			'content': '""',
-			'cursor': 'none',
-			'display': 'block',
-			'left': '0',
-			'position': 'fixed',
-			'right': '0',
-			'top': '0',
-			'z-index': '999999'
+			bottom: 0,
+			content: '""',
+			cursor: 'none',
+			display: 'block',
+			left: 0,
+			position: 'fixed',
+			right: 0,
+			top: 0,
+			zIndex: 999999
 		}
-	}),
-	SIDEBAR: getCSSRulesString({
+	},
+	SIDEBAR: {
 		':host': {
-			'--mdc-drawer-width': '0px !important'
+			MdcDrawerWidth: '0px !important'
 		},
 		'partial-panel-resolver': {
-			'--mdc-top-app-bar-width': '100% !important'
+			MdcTopAppBarWidth: '100% !important'
 		},
-		'ha-drawer > ha-sidebar': {
-			'display': 'none'
-		},
+		'ha-drawer > ha-sidebar': false,
 		'.header': {
-			'width': '100% !important'
+			width: '100% !important'
 		}
-	}),
-	ASIDE: getDisplayNoneRulesString('.mdc-drawer'),
-	OVERFLOW_MENU: getDisplayNoneRulesString(
+	},
+	ASIDE: getDisplayNoneRules('.mdc-drawer'),
+	OVERFLOW_MENU: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU}`
 	),
-	BLOCK_OVERFLOW: getCSSRulesString({
+	BLOCK_OVERFLOW: {
 		[`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU}`]: {
 			'pointer-events': 'none !important'
 		}
-	}),
-	SEARCH: getDisplayNoneRulesString(
+	},
+	SEARCH: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.SEARCH}"]`,
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU} > ${ELEMENT.OVERLAY_MENU_ITEM}[data-selector="${MENU.SEARCH}"]`
 	),
-	ASSISTANT: getDisplayNoneRulesString(
+	ASSISTANT: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.ASSIST}"]`,
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU} > ${ELEMENT.OVERLAY_MENU_ITEM}[data-selector="${MENU.ASSIST}"]`
 	),
-	REFRESH: getDisplayNoneRulesString(
+	REFRESH: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU} > ${ELEMENT.OVERLAY_MENU_ITEM}[data-selector="${MENU.REFRESH}"]`
 	),
-	UNUSED_ENTITIES: getDisplayNoneRulesString(
+	UNUSED_ENTITIES: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU} > ${ELEMENT.OVERLAY_MENU_ITEM}[data-selector="${MENU.UNUSED_ENTITIES}"]`,
 	),
-	RELOAD_RESOURCES: getDisplayNoneRulesString(
+	RELOAD_RESOURCES: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU} > ${ELEMENT.OVERLAY_MENU_ITEM}[data-selector="${MENU.RELOAD_RESOURCES}"]`
 	),
-	EDIT_DASHBOARD: getDisplayNoneRulesString(
+	EDIT_DASHBOARD: getDisplayNoneRules(
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ha-icon-button[data-selector="${MENU.EDIT_DASHBOARD}"]`,
 		`${ELEMENT.TOOLBAR} > ${ELEMENT.ACTION_ITEMS} > ${ELEMENT.BUTTON_MENU} > ${ELEMENT.OVERLAY_MENU_ITEM}[data-selector="${MENU.EDIT_DASHBOARD}"]`
 	),
-	DIALOG_HEADER_HISTORY: getDisplayNoneRulesString(
+	DIALOG_HEADER_HISTORY: getDisplayNoneRules(
 		`${ELEMENT.HA_DIALOG_HEADER} > ${ELEMENT.MENU_ITEM}[data-selector="${MENU.DIALOG_HISTORY}"]`
 	),
-	DIALOG_HEADER_SETTINGS: getDisplayNoneRulesString(
+	DIALOG_HEADER_SETTINGS: getDisplayNoneRules(
 		`${ELEMENT.HA_DIALOG_HEADER} > ${ELEMENT.MENU_ITEM}[data-selector="${MENU.DIALOG_SETTINGS}"]`
 	),
-	DIALOG_HEADER_OVERFLOW: getDisplayNoneRulesString(
+	DIALOG_HEADER_OVERFLOW: getDisplayNoneRules(
 		`${ELEMENT.HA_DIALOG_HEADER} > ${ELEMENT.BUTTON_MENU}`
 	),
-	DIALOG_HISTORY: getDisplayNoneRulesString(
+	DIALOG_HISTORY: getDisplayNoneRules(
 		ELEMENT.HA_DIALOG_HISTORY
 	),
-	DIALOG_LOGBOOK: getDisplayNoneRulesString(
+	DIALOG_LOGBOOK: getDisplayNoneRules(
 		ELEMENT.HA_DIALOG_LOGBOOK
 	),
-	DIALOG_ATTRIBUTES: getDisplayNoneRulesString(
+	DIALOG_ATTRIBUTES: getDisplayNoneRules(
 		ELEMENT.HA_DIALOG_ATTRIBUTES
 	),
-	DIALOG_MEDIA_ACTIONS: getDisplayNoneRulesString(
-		'.controls'
-	),
-	DIALOG_TIMER_ACTIONS: getDisplayNoneRulesString(
-		'.actions'
-	),
-	DIALOG_UPDATE_ACTIONS: getDisplayNoneRulesString(
+	DIALOG_MEDIA_ACTIONS: getDisplayNoneRules('.controls'),
+	DIALOG_TIMER_ACTIONS: getDisplayNoneRules('.actions'),
+	DIALOG_UPDATE_ACTIONS: getDisplayNoneRules(
 		'.actions',
 		`hr:has(+ .actions)`
 	),
-	DIALOG_CLIMATE_CONTROL_SELECT: getDisplayNoneRulesString(
+	DIALOG_CLIMATE_CONTROL_SELECT: getDisplayNoneRules(
 		ELEMENT.HA_DIALOG_CLIMATE_CONTROL_SELECT
 	),
-	DIALOG_CLIMATE_TEMPERATURE_BUTTONS: getDisplayNoneRulesString(
+	DIALOG_CLIMATE_TEMPERATURE_BUTTONS: getDisplayNoneRules(
 		ELEMENT.HA_DIALOG_CLIMATE_TEMPERATURE_BUTTONS
 	),
-	DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION: getDisplayNoneRulesString(
+	DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION: getDisplayNoneRules(
 		ELEMENT.HA_DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION,
 		ELEMENT.HA_DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION_SLIDER,
 		ELEMENT.HA_DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION_TARGET_BORDER,
 		ELEMENT.HA_DIALOG_CLIMATE_CIRCULAR_SLIDER_INTERACTION_TARGET
 	),
-	DIALOG_LIGHT_CONTROL_ACTIONS: getDisplayNoneRulesString(
+	DIALOG_LIGHT_CONTROL_ACTIONS: getDisplayNoneRules(
 		`.controls > ${ELEMENT.HA_DIALOG_LIGHT_BRIGHTNESS} + ${ELEMENT.HA_DIALOG_LIGHT_CONTROLS}`
 	),
-	DIALOG_LIGHT_COLOR_ACTIONS: getDisplayNoneRulesString(
+	DIALOG_LIGHT_COLOR_ACTIONS: getDisplayNoneRules(
 		`.controls > ${ELEMENT.HA_DIALOG_LIGHT_COLORS}`
 	),
-	DIALOG_LIGHT_SETTINGS_ACTIONS: getDisplayNoneRulesString(
+	DIALOG_LIGHT_SETTINGS_ACTIONS: getDisplayNoneRules(
 		`.controls:has(> ${ELEMENT.HA_DIALOG_LIGHT_BRIGHTNESS}) + div > ${ELEMENT.HA_DIALOG_LIGHT_SETTINGS}`
 	),
-	DIALOG_SHOW_MORE: getDisplayNoneRulesString(
-		`.header a`
-	)
+	DIALOG_SHOW_MORE: getDisplayNoneRules('.header a')
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,8 +104,6 @@ export interface HassConnection {
     }
 }
 
-export type StyleElement = Element | ShadowRoot | Element[] | ShadowRoot[];
-
 declare global {
     interface Window {
         kioskModeEntities: Record<string, string[]>;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,10 +1,5 @@
+import { HomeAssistant, Version } from '@types';
 import {
-	HomeAssistant,
-	StyleElement,
-	Version
-} from '@types';
-import {
-	STYLES_PREFIX,
 	TRUE,
 	MENU_REFERENCES,
 	MAX_ATTEMPTS,
@@ -17,40 +12,6 @@ import {
 // Convert to array
 export const toArray = <T>(x: T | T[]): T[] => {
 	return Array.isArray(x) ? x : [x];
-};
-
-const getElementName = (elem: Element | ShadowRoot): string => {
-	if (elem instanceof ShadowRoot) {
-		return elem.host.localName;
-	}
-	return elem.localName;
-};
-
-export const styleExists = (elem: Element | ShadowRoot): HTMLStyleElement => {
-	const name = getElementName(elem);
-	return elem.querySelector<HTMLStyleElement>(`#${STYLES_PREFIX}_${name}`);
-};
-
-export const addStyle = (css: string, elem: Element | ShadowRoot | null): void => {
-	if (!elem) return;
-	const name = getElementName(elem);
-	let style = styleExists(elem);
-	if (!style) {
-		style = document.createElement('style');
-		style.setAttribute('id', `${STYLES_PREFIX}_${name}`);
-		elem.appendChild(style);
-	}
-	style.innerHTML = css;
-};
-
-export const removeStyle = (elements: StyleElement | null): void => {
-	if (!elements) return;
-	toArray(elements).forEach((elem) => {
-		const name = getElementName(elem);
-		if (styleExists(elem)) {
-			elem.querySelector(`#${STYLES_PREFIX}_${name}`).remove();
-		}
-	});
 };
 
 // Get cache key
@@ -95,29 +56,11 @@ export const resetCache = () => {
 	});
 };
 
-// Convert a CSS in JS to string
-export const getCSSString = (cssInJs: Record<string, string>): string => {
-	return Object.entries(cssInJs)
-		.map((entry: [string, string]): string => {
-			const [decl, value] = entry;
-			return `${decl}:${value}`;
-		})
-		.join(';') + ';';
-};
-
-// Convert a CSS rules object to string
-export const getCSSRulesString = (cssRulesInJs: Record<string, Record<string, string>>): string => {
-	return Object.entries(cssRulesInJs)
-		.map((entry: [string, Record<string, string>]): string => {
-			const [rule, cssInJs] = entry;
-			return `${rule}{${getCSSString(cssInJs)}}`;
-		}).join('');
-};
-
-export const getDisplayNoneRulesString = (...rules: string[]): string => {
-	return rules.map((rule: string): string => {
-		return `${rule}{display: none !important;}`;
-	}).join('');
+export const getDisplayNoneRules = (...rules: string[]): Record<string, false> => {
+	const rulesEntries = toArray(rules).map((rule: string): [string, false] => {
+		return [rule, false];
+	});
+	return Object.fromEntries(rulesEntries);
 };
 
 const getHAResources = (ha: HomeAssistant): Promise<Record<string, Record<string, string>>> => {


### PR DESCRIPTION
This pull request removes the custom style management and starts to use [home-assistant-styles-manager](https://github.com/elchininet/home-assistant-styles-manager) which accepts CSS-in-JS directly and converts the declarations from camel case to kebab case automatically, so all the code to convert the style objects to strings have been refactored to send the objects straight away.