### PR TITLE
Remove local getPromosableElement utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
+    "get-promisable-result": "^1.0.1",
     "home-assistant-query-selector": "4.3.0",
     "home-assistant-styles-manager": "3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      get-promisable-result:
+        specifier: ^1.0.1
+        version: 1.0.1
       home-assistant-query-selector:
         specifier: 4.3.0
         version: 4.3.0

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -4,7 +4,6 @@ import {
 	MENU_REFERENCES,
 	MAX_ATTEMPTS,
 	RETRY_DELAY,
-	NAMESPACE,
 	ELEMENT,
 	OPTION
 } from '@constants';
@@ -102,30 +101,6 @@ export const getMenuTranslations = async(
 		return [resourcesTranslated[prop], reference];
 	});
 	return Object.fromEntries(menuTranslationsEntries);
-};
-
-export const getPromisableElement = <T>(
-	getElement: () => T,
-	check: (element: T) => boolean,
-	elementName: string
-): Promise<T> => {
-	return new Promise<T>((resolve, reject) => {
-		let attempts = 0;
-		const select = () => {
-			const element: T = getElement();
-			if (element && check(element)) {
-				resolve(element);
-			} else {
-				attempts++;
-				if (attempts < MAX_ATTEMPTS) {
-					setTimeout(select, RETRY_DELAY);
-				} else {
-					reject(new Error(`${NAMESPACE}: Cannot select ${elementName} after ${MAX_ATTEMPTS} attempts. Giving up!`));
-				}
-			}
-		};
-		select();
-	});
 };
 
 export const addMenuItemsDataSelectors = (


### PR DESCRIPTION
This pull request removes the `getPromisableElement` utility and replace it by the `getPromisableResult` utility from [get-promisable-result](https://github.com/elchininet/get-promisable-result). This removes some uncovered branches from the end-to-end tests and slightly increases the coverage from `84.67%` to `85.51%`.

<img width="575" alt="image" src="https://github.com/user-attachments/assets/47c10265-5a31-4cc0-85cb-4dc6e5dadb97">
