### PR TITLE
Upload the coverage report to Coveralls

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,10 @@ jobs:
           pnpm test:all
       - name: Create coverage
         run: pnpm coverage:report
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CodeQL](https://github.com/NemesisRE/kiosk-mode/actions/workflows/github-code-scanning/codeql/badge.svg?style=flat-square)](https://github.com/NemesisRE/kiosk-mode/security/code-scanning/tools/CodeQL/status)
 [![HACS Action](https://github.com/NemesisRE/kiosk-mode/actions/workflows/hacs.yaml/badge.svg)](https://github.com/NemesisRE/kiosk-mode/actions/workflows/hacs.yaml)
 [![Test](https://github.com/NemesisRE/kiosk-mode/actions/workflows/test.yaml/badge.svg)](https://github.com/NemesisRE/kiosk-mode/actions/workflows/test.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/NemesisRE/kiosk-mode/badge.svg?branch=master)](https://coveralls.io/github/NemesisRE/kiosk-mode?branch=master)
 [![release](https://img.shields.io/github/v/release/NemesisRE/kiosk-mode.svg)](https://github.com/NemesisRE/kiosk-mode/releases)
 [![downloads](https://img.shields.io/github/downloads/NemesisRE/kiosk-mode/total)](https://github.com/NemesisRE/kiosk-mode/releases)
 


### PR DESCRIPTION
This pull request uploads the coverage report to Coveralls using the `coverallsapp` Github action and adds a coverage badge to the README.