### PR TITLE
Small fix in the KIOSK MODE COMPLEMENTS documentation

### DIFF
--- a/KIOSK-MODE-COMPLEMENTS.md
+++ b/KIOSK-MODE-COMPLEMENTS.md
@@ -57,7 +57,7 @@ your-custom-theme:
       .toolbar ha-icon-button-arrow-prev {
         display: none !important;
       }
-    
+```
 
 ### More-info dialogs
 


### PR DESCRIPTION
This pull request fixes a section in the `KIOSK-MODE-COMPLEMENTS` documentation.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/684819c8-c2c6-48d0-b255-36f6ffb3bc06) | ![image](https://github.com/user-attachments/assets/18121f8a-075f-4cf1-b67c-0fb487d0f18d) |

