### PR TITLE
Correct Home Assistant < 2025.3.0 detection

### DIFF
--- a/src/kiosk-mode.ts
+++ b/src/kiosk-mode.ts
@@ -193,7 +193,13 @@ class KioskMode implements KioskModeRunner {
 
 		// Get menu translations
 		// Store Home Assistant Legacy variable (Home Assistant < 2025.3.x)
-		const isLegacyHomeAssistant = this.version?.[0] < 2025 || this.version?.[1] < 3;
+		const isLegacyHomeAssistant = (
+			this.version?.[0] < 2025 ||
+			(
+				this.version?.[0] === 2025 &&
+				this.version?.[1] < 3
+			)
+		);
 
 		getMenuTranslations(this.ha, isLegacyHomeAssistant)
 			.then((menuTranslations: Record<string, string>) => {


### PR DESCRIPTION
[The recent change](https://github.com/NemesisRE/kiosk-mode/pull/351) to fix options dependant on Home Assistant translations has a check to detect if the Home Assistant version is lower than the version `2025.3.0`. The check to do that will also mark Home Assistant < `2026.3.x` (or any other major version lower than `x.3.x`) as legacy version. Even if at that time this check should have been removed, this pull request fixes the check to make it be applied correctly.