### PR TITLE
Configure Dependabot to update Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,18 @@ updates:
     labels:
       - dependencies
     versioning-strategy: increase
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
+    commit-message:
+      prefix: "[Github Actions]"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+    labels:
+      - configuration

--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:      
   beta-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request configures Dependabot to update Github actions.