### PR TITLE
Update PNPM in Github workflows

### DIFF
--- a/.github/workflows/build-pre-release.yaml
+++ b/.github/workflows/build-pre-release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set-up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set-up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
[After removing](https://github.com/NemesisRE/kiosk-mode/pull/360) the dependency on `package.json` builtin variables, the project is ready to migrate to `pnpm@10`. This pull request bumps `pnpm` to version `10` in the Github workflows.

