### PR TITLE
Add Beta-tests badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![release](https://img.shields.io/github/v/release/NemesisRE/kiosk-mode.svg)](https://github.com/NemesisRE/kiosk-mode/releases)
 [![downloads](https://img.shields.io/github/downloads/NemesisRE/kiosk-mode/total)](https://github.com/NemesisRE/kiosk-mode/releases)
 
+[![Home Assistant Nightly Beta Tests](https://github.com/NemesisRE/kiosk-mode/actions/workflows/ha-beta-tests.yaml/badge.svg)](https://github.com/NemesisRE/kiosk-mode/actions/workflows/ha-beta-tests.yaml)
+
 Hides the header and/or sidebar drawer in [Home Assistant](https://www.home-assistant.io/) lovelace dashboards.
 
 ![image](example.png)


### PR DESCRIPTION
This pull request adds the `Beta-tests` badge to the README to make it more visible when the tests are failing with the `Home Assistant` version in development.

<img width="890" alt="image" src="https://github.com/user-attachments/assets/94be2d8c-d5b2-4c52-ae59-ab5cebcc9ffc" />
