### PR TITLE
Correct the Home Assistant version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Hides the header and/or sidebar drawer in [Home Assistant](https://www.home-assi
 
 > [!IMPORTANT]  
 > 1. If you have `Home Assistant` `2025.5.1` or greater installed, the minimum compatible version that you can install is `Kiosk Mode` `v7.0.0`. If you are in a lower version of `Home Assistant`, the latest compatible version that you can install is `v6.7.0`.
-> 2. If you have `Home Assistant` `2025.10.1` or greater installed, the minimum compatible version that you can install is `Kiosk Mode` `v8.0.0`. If you are in a version of `Home Assistant` between `2025.5.1` and `2025.10.1`, the latest compatible version that you can install is `v7.4.0`.
+> 2. If you have `Home Assistant` `2025.10.0` or greater installed, the minimum compatible version that you can install is `Kiosk Mode` `v8.0.0`. If you are in a version of `Home Assistant` between `2025.5.1` and `2025.10.0`, the latest compatible version that you can install is `v7.4.0`.
 
 <details>
   <summary><b>Installation through HACS</b></summary>


### PR DESCRIPTION
The Home Assistant version for this month resulted `2025.10.0` instead of `2025.10.1`. This has been corrected in the note in the README.