### PR TITLE
Fix the yaml code of aligning tabs to the center in Kiosk Mode Complements

### DIFF
--- a/KIOSK-MODE-COMPLEMENTS.md
+++ b/KIOSK-MODE-COMPLEMENTS.md
@@ -38,8 +38,8 @@ This method aligns the Home Assistant header tabs to the center. You need to use
 your-custom-theme:
   card-mod-theme: your-custom-theme
   card-mod-root-yaml: |
-    ha-tabs$: |
-      #tabsContainer {
+    .: |
+      .toolbar ha-tab-group {
         display: flex;
         justify-content: center;
       }


### PR DESCRIPTION
This pull request fixes the example of aligning the header tabs to the center after the latest Home Assistant changes.

Closes: #437 