### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,4 +1,6 @@
 name: HACS Action
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NemesisRE/kiosk-mode/security/code-scanning/13](https://github.com/NemesisRE/kiosk-mode/security/code-scanning/13)

To fix this problem, you should add a `permissions` block that restricts the GITHUB_TOKEN to the minimal needed privilege for the workflow. For most read-only Actions workflows, setting `contents: read` at either the workflow or job level is recommended. Since the workflow provided does not include steps that require write access to contents, issues, or pull requests, the safest approach is to add `permissions: { contents: read }` — either at the top level or within the `hacs` job. It is generally best practice and most clear to set it at the workflow top level (just below the `name:` or `on:` keys), so it applies to all jobs in the workflow, unless different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
