### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -1,4 +1,6 @@
 name: Home Assistant Beta Nightly Tests
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/NemesisRE/kiosk-mode/security/code-scanning/12](https://github.com/NemesisRE/kiosk-mode/security/code-scanning/12)

To address this issue, you should add a `permissions` key to the workflow (at the top level, just after the `name` field and before `on:`, or at the job level). The minimal safe starting point, as recommended, is `permissions: contents: read`. Since the shown steps do not perform any GitHub write operations (like opening issues or PRs), only reading contents (for `actions/checkout`), this is sufficient. The permissions block should be inserted after the `name` field (line 1) and before the `on` definition (line 3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
