### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NemesisRE/kiosk-mode/security/code-scanning/11](https://github.com/NemesisRE/kiosk-mode/security/code-scanning/11)

To fix this problem, we should add a `permissions` block to the workflow definition with the least privilege required for the workflow to operate correctly. Since the only usage of the GITHUB_TOKEN in this workflow is for reporting coverage to Coveralls, and all other steps do not require write access to the repository or interact with issues or pull-requests, the safest minimum is `contents: read`. To achieve this, add a `permissions:` block after `name:` and before `on:` at the root of `.github/workflows/test.yaml`. No other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
