### PR TITLE
Set cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "09:00"
+    cooldown:
+      default-days: 1
     commit-message:
       prefix: "[Dependencies]"
     groups:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
-minimumReleaseAgeExclude:
-  - home-assistant-query-selector@7.0.0
 overrides:
   brace-expansion@>=5.0.0 <5.0.6: ^5.0.6


### PR DESCRIPTION
This pull request sets [a cooldown period](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) in the Depndabot configuration to avoid updating dependencies that have been released within one day.

>Note: as part of this pull request the plugin bundles have been updated.