### PR TITLE
Allow minor and patches TypeScript updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       prefix: "[Dependencies]"
     ignore:
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dependencies-prod:
         dependency-type: "production"


### PR DESCRIPTION
This pull request configures Dependabot to allow minor and patches TypeScript updates.